### PR TITLE
Legg ved valgfri sjekksummer i konverteringsinformasjonen

### DIFF
--- a/kapitler/030-noark-5-datamodell.rst
+++ b/kapitler/030-noark-5-datamodell.rst
@@ -634,6 +634,10 @@ Konvertering til arkivformat
 
 Alle arkivdokumenter som skal avleveres må være i arkivformat. Konvertering til arkivformat skal foretas senest ved avslutning av mappe. Systemet skal logge alle konverteringer, og informasjon om dette skal tas med ved deponering/avlevering.
 
+Som del av konvertering bør det logges sjekksum for filen det ble
+konvertert fra (fra-filen), og filen det ble konvertert til
+(til-filen), som kan brukes til å dokumentere konverteringskjeden.
+
 .. list-table:: **Krav til konvertering til arkivformat**
    :widths: 1 8 1 4
    :header-rows: 1
@@ -672,6 +676,13 @@ Alle arkivdokumenter som skal avleveres må være i arkivformat. Konvertering ti
      registreringer og/eller dokumentbeskrivelser som ikke inneholder
      dokumenter lagret i godkjent arkivformat.
    - O
+   -
+ * - 2.7.26
+   - For hver konvertering bør det registreres sjekksum for fra-filen
+     og til-filen, slik at kjeden av konverteringer dokumenteres.  Det
+     brukes samme sjekksumalgoritme som i dokumentobjekt, slik at
+     kjeden frem til arkivformat er dokumentert.
+   - V
    - 
 
 Sletting av versjoner, varianter og formater

--- a/kapitler/110-vedlegg_1_metadatakatalog-auto.rst
+++ b/kapitler/110-vedlegg_1_metadatakatalog-auto.rst
@@ -4422,7 +4422,7 @@ Tekniske metadata
  * - **Arkivenhet**
    - dokumentobjekt
  * - **Kilde**
-   - Påføres automatisk i forbindelse med eksport for avlevering
+   - Påføres automatisk ved mottak eller i forbindelse med eksport for avlevering.
  * - **Arv**
    - Nei
  * - **Betingelser**
@@ -4443,7 +4443,7 @@ Tekniske metadata
  * - **Arkivenhet**
    - dokumentobjekt
  * - **Kilde**
-   - Registreres automatisk i forbindelse med eksport for avlevering
+   - Registreres automatisk mottak eller i forbindelse med eksport for avlevering.
  * - **Arv**
    - Nei
  * - **Betingelser**
@@ -4639,4 +4639,88 @@ Tekniske metadata
    - Kan ikke endres
  * - **Kommentarer**
    - MIME-type for bruk når fil overføres via for eksempel HTTP og SMTP.  MIME-typer er definert i IETF RFC 2046 og en katalog over offisielle verdier vedlikeholdes av Internet Assigned Numbers Authority (IANA).  Merk at en PRONOM-kode kan ha flere kjente MIME-typer og en MIME-type kan være koblet til flere PRONOM-koder.
+
+.. list-table::
+   :widths: 2 6
+   :header-rows: 0
+
+ * - **Nr**
+   - **M717**
+ * - **Navn**
+   - **konvertertFraSjekksum**
+ * - **Definisjon**
+   - En verdi som beregnes ut fra innholdet i dokumentet, og som dermed gir integritetssikring til dokumentets innhold
+ * - **Arkivenhet**
+   - konvertering
+ * - **Kilde**
+   - Påføres automatisk ved konvertering.
+ * - **Arv**
+   - Nei
+ * - **Betingelser**
+   - Kan ikke endres. Sjekksummen skal være heksadesimal uten noen formatteringstegn.
+ * - **Kommentarer**
+   - Bruker samme verdier som M705 sjekksum.
+
+.. list-table::
+   :widths: 2 6
+   :header-rows: 0
+
+ * - **Nr**
+   - **M718**
+ * - **Navn**
+   - **konvertertFraSjekksumAlgoritme**
+ * - **Definisjon**
+   - Algoritmen som er brukt for å beregne konvertertFraSjekksum
+ * - **Arkivenhet**
+   - konvertering
+ * - **Kilde**
+   - Registreres automatisk i forbindelse ved konvertering
+ * - **Arv**
+   - Nei
+ * - **Betingelser**
+   - Kan ikke endres.  Kopi av algoritmen til dokumentobjekt for kildefil ved konvertering.
+ * - **Kommentarer**
+   - Bruker samme verdier som M706 sjekksumAlgoritme.
+
+.. list-table::
+   :widths: 2 6
+   :header-rows: 0
+
+ * - **Nr**
+   - **M719**
+ * - **Navn**
+   - **konvertertTilSjekksum**
+ * - **Definisjon**
+   - En verdi som beregnes ut fra innholdet i dokumentet, og som dermed gir integritetssikring til dokumentets innhold
+ * - **Arkivenhet**
+   - konvertering
+ * - **Kilde**
+   - Påføres automatisk ved konvertering.
+ * - **Arv**
+   - Nei
+ * - **Betingelser**
+   - Kan ikke endres. Sjekksummen skal være heksadesimal uten noen formatteringstegn.
+ * - **Kommentarer**
+   - Bruker samme verdier som M705 sjekksum.
+
+.. list-table::
+   :widths: 2 6
+   :header-rows: 0
+
+ * - **Nr**
+   - **M720**
+ * - **Navn**
+   - **konvertertFraSjekksumAlgoritme**
+ * - **Definisjon**
+   - Algoritmen som er brukt for å beregne konvertertTilSjekksum
+ * - **Arkivenhet**
+   - konvertering
+ * - **Kilde**
+   - Registreres automatisk i forbindelse med konvertering.
+ * - **Arv**
+   - Nei
+ * - **Betingelser**
+   - Kan ikke endres.  Kopi av algoritmen til dokumentobjekt for målfil ved konvertering.
+ * - **Kommentarer**
+   - Bruker samme verdier som M706 sjekksumAlgoritme.
 

--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -1501,6 +1501,30 @@ Metadata for *konvertering*
    - 1
    - A
    - Tekststreng
+ * - M717
+   - konvertertFraSjekksum
+   -
+   - 0-1
+   - A
+   - Tekststreng
+ * - M718
+   - konvertertFraSjekksumAlgoritme
+   -
+   - 0-1
+   - A
+   - Tekststreng
+ * - M719
+   - konvertertTilSjekksum
+   -
+   - 0-1
+   - A
+   - Tekststreng
+ * - M720
+   - konvertertTilSjekksumAlgoritme
+   -
+   - 0-1
+   - A
+   - Tekststreng
  * - M714
    - konverteringsverktoey
    - 

--- a/metadata/M705.yaml
+++ b/metadata/M705.yaml
@@ -6,7 +6,8 @@ Datatype: Tekststreng
 Definisjon: En verdi som beregnes ut fra innholdet i dokumentet, og som dermed gir
   integritetssikring til dokumentets innhold
 Gruppe: Tekniske metadata
-Kilde: Påføres automatisk i forbindelse med eksport for avlevering
+Kilde: Påføres automatisk ved mottak eller i forbindelse med eksport
+  for avlevering.
 Kommentarer:
 Navn: sjekksum
 Nr: M705

--- a/metadata/M706.yaml
+++ b/metadata/M706.yaml
@@ -5,7 +5,8 @@ Betingelser: Kan ikke endres. Algoritmen som skal brukes inntil videre er SHA256
 Datatype: Tekststreng
 Definisjon: Algoritmen som er brukt for å beregne sjekksummen
 Gruppe: Tekniske metadata
-Kilde: Registreres automatisk i forbindelse med eksport for avlevering
+Kilde: Registreres automatisk mottak eller i forbindelse med eksport
+  for avlevering.
 Kommentarer:
 Navn: sjekksumAlgoritme
 Nr: M706

--- a/metadata/M717.yaml
+++ b/metadata/M717.yaml
@@ -1,0 +1,13 @@
+Arkivenhet: konvertering
+Arv: Nei
+Avleveres: A
+Betingelser: Kan ikke endres. Sjekksummen skal være heksadesimal uten noen formatteringstegn.
+Datatype: Tekststreng
+Definisjon: En verdi som beregnes ut fra innholdet i dokumentet, og som
+  dermed gir integritetssikring til dokumentets innhold
+Gruppe: Tekniske metadata
+Kilde: Påføres automatisk ved konvertering.
+Kommentarer: Bruker samme verdier som M705 sjekksum.
+Navn: konvertertFraSjekksum
+Nr: M717
+X: true

--- a/metadata/M718.yaml
+++ b/metadata/M718.yaml
@@ -1,0 +1,13 @@
+Arkivenhet: konvertering
+Arv: Nei
+Avleveres: A
+Betingelser: Kan ikke endres.  Kopi av algoritmen til dokumentobjekt
+  for kildefil ved konvertering.
+Datatype: Tekststreng
+Definisjon: Algoritmen som er brukt for å beregne konvertertFraSjekksum
+Gruppe: Tekniske metadata
+Kilde: Registreres automatisk i forbindelse ved konvertering
+Kommentarer: Bruker samme verdier som M706 sjekksumAlgoritme.
+Navn: konvertertFraSjekksumAlgoritme
+Nr: M718
+X: true

--- a/metadata/M719.yaml
+++ b/metadata/M719.yaml
@@ -1,0 +1,13 @@
+Arkivenhet: konvertering
+Arv: Nei
+Avleveres: A
+Betingelser: Kan ikke endres. Sjekksummen skal være heksadesimal uten noen formatteringstegn.
+Datatype: Tekststreng
+Definisjon: En verdi som beregnes ut fra innholdet i dokumentet, og som
+  dermed gir integritetssikring til dokumentets innhold
+Gruppe: Tekniske metadata
+Kilde: Påføres automatisk ved konvertering.
+Kommentarer: Bruker samme verdier som M705 sjekksum.
+Navn: konvertertTilSjekksum
+Nr: M719
+X: true

--- a/metadata/M720.yaml
+++ b/metadata/M720.yaml
@@ -1,0 +1,13 @@
+Arkivenhet: konvertering
+Arv: Nei
+Avleveres: A
+Betingelser: Kan ikke endres.  Kopi av algoritmen til dokumentobjekt
+  for målfil ved konvertering.
+Datatype: Tekststreng
+Definisjon: Algoritmen som er brukt for å beregne konvertertTilSjekksum
+Gruppe: Tekniske metadata
+Kilde: Registreres automatisk i forbindelse med konvertering.
+Kommentarer: Bruker samme verdier som M706 sjekksumAlgoritme.
+Navn: konvertertFraSjekksumAlgoritme
+Nr: M720
+X: true


### PR DESCRIPTION
Med dagens beskrivelse av konverteringsinformasjon er det ikke
mulig verifisere konverteringskjeder.  Hvis flere konverteringskjeder
er oppgitt, så vil det  ikke være mulig å vite hvilken kjende en gitt
konvertering tilhører.

Et eksempel er et innkommet ODT-dokument, som konverteres til DOCX, så
til PDF og så til PDF/A.  Hvis en så oppdager at DOCX til PDF-konverteringen
feilet og gjør en ny konvertering, så er det kun tidsstemplet som kan brukes
til å forsøke å gjenskape konverteringskjeden.

Ved å ta med sjekksum (M705) til fra- og til-fil i konverteringsoppføringen,
så blir det mulig å identifisere hvilke deler av kjeden som hører sammen
ved å se hvilken fra-fil i en konvertering som har samme sjekksum som
til-fil i en annen konvertering.  Dette vil også kunne brukes til å oppdage
brutte kjeder, hvis en fil har vært endret på disk mellom to konverteringer.

Da konvertering vil ha to sjekksumverdier (det vil si M705 sjekksum), så må
disse feltene gis to ulike navn. Verdiene konvertertFraSjekksum og
konvertertTilSjekksum er altså ment å være to instanser av
metadatakatalogoppføring M705, ikke to nye typer.

Hvis kjeden skal kunne følges må en sjekksum påføres ved konvertering og
ikke ved avlevering.  Beskrivelsen av M705 er justert for å ta høyde for
dette.