### PR TITLE
Endret navn på M506 fra 'grad' til 'graderingskode'

### DIFF
--- a/kapitler/110-vedlegg_1_metadatakatalog-auto.rst
+++ b/kapitler/110-vedlegg_1_metadatakatalog-auto.rst
@@ -2657,7 +2657,7 @@ Skjerming og gradering
  * - **Nr**
    - **M506**
  * - **Navn**
-   - **gradering**
+   - **graderingskode**
  * - **Obligatorisk/valgfri**
    - Betinget obligatorisk
  * - **Forekomster**

--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -1849,7 +1849,7 @@ Ved avlevering skal metadata om gradering være gruppert inn i alle nivåer i ar
    - **Avl.**
    - **Datatype**
  * - M506
-   - gradering
+   - graderingskode
    - 
    - 1
    - A

--- a/metadata/M506.yaml
+++ b/metadata/M506.yaml
@@ -21,6 +21,6 @@ Kilde: Registreres manuelt ved valg fra liste, kan også registres automatisk
 Kommentarer: Dokumenter gradert "Strengt hemmelig", "Hemmelig", "Konfidensielt" og
   "Strengt fortrolig" skal føres i en egen journal som i sin helhet er unntatt fra
   innsyn.
-Navn: gradering
+Navn: graderingskode
 Nr: M506
 Obligatorisk/valgfri: Betinget obligatorisk


### PR DESCRIPTION
Krav 4.5.21 og 4.5.22 snakker om disse verdiene som graderingskode,
tillegg A og B bruker navnet 'gradering', tjenestegrensesnitt-
spesifikasjonen bruker navnet 'graderingskode' og XSD-skjema bruker
navnet 'grad'.

Bakgrunnen er at det var en liten navnekollisjon, der XSD hadde en
entitet ved navn 'gradering', og en metadatakatalogoppføring ved
navn 'gradering'.  Sistnevnte ble endret til 'grad' i XSD, men ikke
i Noark 5-spesifikasjonen og tjenestegrensesnittet.

Navnet 'grad' kan misforstås til å gjelde temperatur eller vinkel,
mens 'graderingskode' er mer entydig.  Endrer derfor til
'graderingskode' i tillegg A (Metadatakatalog) og B (Metadata
gruppert på objekter).  XSD må endres tilsvarende.

XSD-endringsforslag kan ses på
https://github.com/arkivverket/schemas/issues/13 .