### PR TITLE
Datatypen for antallJournalposter skal være Heltall, ikke Tekststreng

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -2430,7 +2430,7 @@ Metadata for *journalhode*
    - 
    - 1
    - A
-   - Tekststreng
+   - Heltall
 
 Metadata for *arkivskaper*
 **************************

--- a/metadata/M609.yaml
+++ b/metadata/M609.yaml
@@ -3,7 +3,7 @@ Arkivenhet: 'Egne filer med journalutskrift for løpende og offentlig journal: l
 Arv: Nei
 Avleveres: A
 Betingelser: Kan ikke endres
-Datatype: Tekststreng
+Datatype: Heltall
 Definisjon: Antall journalposter i rapporten
 Forekomster: '1'
 Gruppe: Logging av hendelser


### PR DESCRIPTION
I metadatakatalogen og i en av to tabeller med oversikt over felter
i journalhode, så var datatypen for antallJournalposter ført opp som
Tekststreng, ikke Heltall.  I den siste tabellen og XSD er datatypen
heltall.

Dette løser en av problemene rapportert i mangelmelding #24.