### PR TITLE
Datatypen for filstoerrelse skal være Heltall, ikke Tekststreng

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -1454,7 +1454,7 @@ Metadata for *dokumentobjekt*
    - 
    - 1
    - A
-   - Tekststreng
+   - Heltall
  * - M716
    - mimeType
    -

--- a/metadata/M707.yaml
+++ b/metadata/M707.yaml
@@ -2,8 +2,8 @@ Arkivenhet: dokumentobjekt
 Arv: Nei
 Avleveres: A
 Betingelser: Kan ikke endres
-Datatype: Tekststreng
-Definisjon: Størrelsen på fila i antall bytes oppgitt med desimaltall
+Datatype: Heltall
+Definisjon: Størrelsen på fila i antall bytes.
 Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk i forbindelse med eksport for avlevering


### PR DESCRIPTION
Datatypen for dette feltet er allerede heltall i i XSD og Tjenestegrensesnitt, mens tillegg B fortsatt har den oppført som tekststreng.

Endret beskrivelsen samtidig til å ikke nevne desimaltall, som kan tolkes som kommatall, hvilket ikke gir mening for antall bytes. I stedet for å oppgi tallsystem i de ulike numeriske feltene, som antallJournalposter, så er det kanskje bedre å skrive annen plass i teksten at alle heltall skal oppgis i titallsystemet.