### PR TITLE
Bytt til dato med klokkeslett for alle tidsstempler

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -270,13 +270,13 @@ Merk: En og bare en av objekttypene *arkiv* eller *arkivdel* grupperes inn i *ar
    - AP.FRADATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M108
    - arkivperiodeSluttDato
    - AP.TILDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M202
    - referanseForloeper
    - 
@@ -572,7 +572,7 @@ Spesialisering av: *mappe*
    - SA.DATO
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M305
    - administrativEnhet
    - (SA.ADMID)
@@ -602,7 +602,7 @@ Spesialisering av: *mappe*
    - SA.UTLDATO
    - 0-1
    - 
-   - Dato
+   - Dato og klokkeslett
  * - M309
    - utlaantTil
    - (SA.UTLTIL)
@@ -648,7 +648,7 @@ Spesialisering av: *mappe*
    - MO.DATO
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M371
    - moetested
    - MO.STED
@@ -944,37 +944,37 @@ Spesialisering av: *registrering*
    - JP.JDATO
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M103
    - dokumentetsDato
    - JP.DOKDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M104
    - mottattDato
    - 
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M105
    - sendtDato
    - JP.EKSPDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M109
    - forfallsdato
    - JP.FORFDATO
    - 0-1
    - 
-   - Dato
+   - Dato og klokkeslett
  * - M110
    - offentlighetsvurdertDato
    - JP.OVDATO
    - 0-1
    - 
-   - Dato
+   - Dato og klokkeslett
  * - M304
    - antallVedlegg
    - JP.ANTVED
@@ -986,7 +986,7 @@ Spesialisering av: *registrering*
    - JP.UTLDATO
    - 0-1
    - 
-   - Dato
+   - Dato og klokkeslett
  * - M309
    - utlaantTil
    - (JP.UTLTIL)
@@ -1062,31 +1062,31 @@ Spesialisering av: *registrering*
    - JP.DOKDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M104
    - mottattDato
    - 
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M105
    - sendtDato
    - JP.EKSPDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M109
    - forfallsdato
    - JP.FORFDATO
    - 0-1
    - 
-   - Dato
+   - Dato og klokkeslett
  * - M110
    - offentlighetsvurdertDato
    - JP.OVDATO
    - 0-1
    - 
-   - Dato
+   - Dato og klokkeslett
  * - M304
    - antallVedlegg
    - JP.ANTVED
@@ -1098,7 +1098,7 @@ Spesialisering av: *registrering*
    - JP.UTLDATO
    - 0-1
    - 
-   - Dato
+   - Dato og klokkeslett
  * - M309
    - utlaantTil
    - (JP.UTLTIL)
@@ -1723,7 +1723,7 @@ Ved avlevering skal metadata om kassasjon arves til (kopieres inn i) alle underl
    - SA.KASSDATO
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
 
 Metadata for *utfoertKassasjon*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1821,7 +1821,7 @@ Ved avlevering skal metadata om skjerming være gruppert inn i alle nivåer i ar
    - JP.AGDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
 
 Metadata for *gradering*
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1901,7 +1901,7 @@ Metadata for *presedens*
    - PS.DATO
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M600
    - opprettetDato
    - 
@@ -2106,13 +2106,13 @@ Metadata for *journalhode*
    - 
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M113
    - journalSluttDato
    - 
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M313
    - seleksjon
    - 
@@ -2307,19 +2307,19 @@ Metadata for *journalpost*
    - JP.JDATO
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M103
    - dokumentetsDato
    - JP.DOKDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M617
    - avskrivningsdato
    - AM.AVSKDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M619
    - avskrivningsmaate
    - AM.AVSKM
@@ -2412,13 +2412,13 @@ Metadata for *journalhode*
    - 
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M113
    - journalSluttDato
    - 
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M313
    - seleksjon
    - 
@@ -2589,19 +2589,19 @@ Metadata for *journalpost*
    - JP.JDATO
    - 1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M103
    - dokumentetsDato
    - JP.DOKDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M617
    - avskrivningsdato
    - AM.AVSKDATO
    - 0-1
    - A
-   - Dato
+   - Dato og klokkeslett
  * - M619
    - avskrivningsmaate
    - AM.AVSKM

--- a/metadata/M100.yaml
+++ b/metadata/M100.yaml
@@ -2,7 +2,7 @@ Arkivenhet: saksmappe
 Arv: Nei
 Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil saksmappen avsluttes
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Datoen saken er opprettet
 Forekomster: '1'
 Gruppe: Datoer

--- a/metadata/M101.yaml
+++ b/metadata/M101.yaml
@@ -2,7 +2,7 @@ Arkivenhet: Journalpost
 Arv: Nei
 Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil arkivering
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Datoen journalposten er journalført
 Forekomster: '1'
 Gruppe: Datoer

--- a/metadata/M102.yaml
+++ b/metadata/M102.yaml
@@ -2,7 +2,7 @@ Arkivenhet: moetemappe
 Arv: Nei
 Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil mappen avsluttes.
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Datoen når et utvalgsmøte blir avholdt
 Forekomster: '1'
 Gruppe: Datoer

--- a/metadata/M103.yaml
+++ b/metadata/M103.yaml
@@ -2,7 +2,7 @@ Arkivenhet: journalpost
 Arv: Nei
 Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil arkivering
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato som er påført selve dokumentet
 Forekomster: 0-1
 Gruppe: Datoer

--- a/metadata/M104.yaml
+++ b/metadata/M104.yaml
@@ -3,7 +3,7 @@ Arv: Nei
 Avleveres: A
 Betingelser: Skal ikke kunne endres ved automatisk registrering, dato for mottak av
   fysiske dokumenter skal kunne endres inntil arkivering
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato et eksternt dokument ble mottatt
 Forekomster: 0-1
 Gruppe: Datoer

--- a/metadata/M105.yaml
+++ b/metadata/M105.yaml
@@ -3,7 +3,7 @@ Arv: Nei
 Avleveres: A
 Betingelser: Skal ikke kunne endres ved automatisk registrering, dato for forsendelse
   av fysiske dokumenter skal kunne endres inntil arkivering
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato et internt produsert dokument ble sendt/ekspedert
 Forekomster: 0-1
 Gruppe: Datoer

--- a/metadata/M106.yaml
+++ b/metadata/M106.yaml
@@ -3,7 +3,7 @@ Arv: Nei
 Avleveres:
 Betingelser: Utlån skal også kunne registreres etter at en saksmappe er avsluttet,
   eller etter at dokumentene i en journalpost ble arkivert.
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato når en fysisk saksmappe eller journalpost ble utlånt
 Forekomster: 0-1
 Gruppe: Datoer

--- a/metadata/M107.yaml
+++ b/metadata/M107.yaml
@@ -2,7 +2,7 @@ Arkivenhet: arkivdel
 Arv: Nei
 Avleveres: A
 Betingelser: Skal kunne endres manuelt
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato for starten av en arkivperiode
 Forekomster: 0-1
 Gruppe: Datoer

--- a/metadata/M108.yaml
+++ b/metadata/M108.yaml
@@ -2,7 +2,7 @@ Arkivenhet: arkivdel
 Arv: Nei
 Avleveres: A
 Betingelser: Skal kunne endres manuelt.
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato for slutten av en arkivperiode
 Forekomster: 0-1
 Gruppe: Datoer

--- a/metadata/M109.yaml
+++ b/metadata/M109.yaml
@@ -2,7 +2,7 @@ Arkivenhet: journalpost
 Arv: Nei
 Avleveres:
 Betingelser:
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato som angir fristen for når et inngående dokument må være besvart
 Forekomster: 0-1
 Gruppe: Datoer

--- a/metadata/M110.yaml
+++ b/metadata/M110.yaml
@@ -2,7 +2,7 @@ Arkivenhet: journalpost
 Arv: Nei
 Avleveres:
 Betingelser:
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Datoen da offentlighetsvurdering ble foretatt
 Forekomster: 0-1
 Gruppe: Datoer

--- a/metadata/M111.yaml
+++ b/metadata/M111.yaml
@@ -2,7 +2,7 @@ Arkivenhet: saksmappe eller journalpost
 Arv: Nei
 Avleveres: A
 Betingelser:
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Datoen på presedensen
 Forekomster: '1'
 Gruppe: Datoer

--- a/metadata/M112.yaml
+++ b/metadata/M112.yaml
@@ -3,7 +3,7 @@ Arkivenhet: 'Egne filer med journalutskrift for løpende og offentlig journal: l
 Arv:
 Avleveres: A
 Betingelser: Startdato skal selekteres på *M101 journaldato*
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Startdato for journalutskriftene som inngår i avleveringspakken.
 Forekomster: '1'
 Gruppe: Datoer

--- a/metadata/M113.yaml
+++ b/metadata/M113.yaml
@@ -3,7 +3,7 @@ Arkivenhet: 'Egne filer med journalutskrift for løpende og offentlig journal: l
 Arv:
 Avleveres: A
 Betingelser: Sluttdato skal selekteres på *M101 journaldato*
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Sluttdato for journalutskriftene som inngår i avleveringspakken.
 Forekomster: '1'
 Gruppe: Datoer

--- a/metadata/M452.yaml
+++ b/metadata/M452.yaml
@@ -2,7 +2,7 @@ Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Ja
 Avleveres: A
 Betingelser:
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato for når dokumentene som tilhører denne arkivenheten skal kunne kasseres,
   eller vurderes for bevaring og kassasjon på ny
 Forekomster: '1'

--- a/metadata/M505.yaml
+++ b/metadata/M505.yaml
@@ -2,7 +2,7 @@ Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Ja
 Avleveres: A
 Betingelser:
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Datoen skjermingen skal oppheves.
 Forekomster: 0-1
 Gruppe: Skjerming og gradering

--- a/metadata/M617.yaml
+++ b/metadata/M617.yaml
@@ -2,7 +2,7 @@ Arkivenhet: journalpost
 Arv: Nei
 Avleveres: A
 Betingelser: Kan ikke endres
-Datatype: Dato
+Datatype: Dato og klokkeslett
 Definisjon: Dato et dokument ble avskrevet
 Forekomster: 0-1
 Gruppe: Logging av hendelser


### PR DESCRIPTION
Endre samtlige dato til dato med klokkeslett i metadatakatalog
og tillegg B.  Endrer type på M100, M101, M102, M103, M104, M105,
M106, M107, M108, M109, M110, M111, M112, M113, M452, M505 og M617.

Relatert til #24
Fixes #38
Fixes #41
Fixes #42
Fixes #43