### PR TITLE
Endret M056 presedensStatus til presedensstatus (med liten S) over alt

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -1963,7 +1963,7 @@ Metadata for *presedens*
    - A
    - Tekststreng
  * - M056
-   - presedensStatus
+   - presedensstatus
    - 
    - 0-1
    - A

--- a/kapitler/media/uml-mappestrukturen-diagram.puml
+++ b/kapitler/media/uml-mappestrukturen-diagram.puml
@@ -110,7 +110,7 @@ class presedens {
   <b>rettskildefaktor</b>
   presedensGodkjentDato
   presedensGodkjentAv
-  presedensStatus
+  presedensstatus
 }
 
 class arkivdel

--- a/kapitler/media/uml-presedens-diagram.puml
+++ b/kapitler/media/uml-presedens-diagram.puml
@@ -19,7 +19,7 @@ class presedens {
   <b>rettskildefaktor</b>
   presedensGodkjentDato
   presedensGodkjentAv
-  presedensStatus
+  presedensstatus
 }
 
 mappe "1" o--> "0..*" registrering

--- a/kapitler/media/uml-registrering-diagram.puml
+++ b/kapitler/media/uml-registrering-diagram.puml
@@ -143,7 +143,7 @@ class presedens {
   <b>rettskildefaktor</b>
   presedensGodkjentDato
   presedensGodkjentAv
-  presedensStatus
+  presedensstatus
 }
 
 class avskrivning {


### PR DESCRIPTION
Oppdaterte tillegg B og UML-diagrammer.  I henhold til navnereglene i
Noark 5 skal det være presedensstatus siden det er ett ord.

XSD må også oppdateres.

Fixes #56