### PR TITLE
Fjernet forekomst-informasjon fra metadatakatalog-oppføringene.

### DIFF
--- a/metadata/M001.yaml
+++ b/metadata/M001.yaml
@@ -6,7 +6,6 @@ Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Regex: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 Definisjon: Globalt unik identifikasjon av arkivenheten (UID).
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet
 Kommentarer: Alle referanser fra en arkivenhet til en annen skal peke til arkivenhetens

--- a/metadata/M002.yaml
+++ b/metadata/M002.yaml
@@ -6,7 +6,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av klassen innenfor klassifikasjonssystemet.
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Alle klasser i et klassifikasjonssystem opprettes vanligvis når et arkivsystem
   tas i bruk. Men enkelte løsninger kan tillate at det opprettes nye klasser ved behov

--- a/metadata/M003.yaml
+++ b/metadata/M003.yaml
@@ -5,7 +5,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av mappen innenfor det arkivet mappen tilhører.
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet etter interne regler
 Kommentarer: |-

--- a/metadata/M004.yaml
+++ b/metadata/M004.yaml
@@ -5,7 +5,6 @@ Betingelser: Skal normalt ikke kunne endres. Ved flytting til en annen mappe, ka
   endring av *registreringsID* forekomme.
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av registreringen innenfor arkivet.
-Forekomster: 0-1
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet etter interne regler
 Kommentarer: |-

--- a/metadata/M005.yaml
+++ b/metadata/M005.yaml
@@ -6,7 +6,6 @@ Betingelser: Skal ikke endres. Den eldste versjonen skal ha det laveste nummeret
   "huller" i nummerrekkefølgen.
 Datatype: Heltall
 Definisjon: Identifikasjon av versjoner innenfor ett og samme dokument.
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når en ny versjon arkiveres
 Kommentarer: Versjonsnummer gjelder bare arkiverte versjoner. Annen versjons­håndtering

--- a/metadata/M006.yaml
+++ b/metadata/M006.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Unik ID for arkivskaperen
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres manuelt ved opprettelsen av arkivet
 Kommentarer: Kan være organisasjonsnummer (Brønnøysundregistrene) eller annen identifikasjon

--- a/metadata/M007.yaml
+++ b/metadata/M007.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Identifikasjon av dokumentene innenfor en registrering
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet
 Kommentarer: Dokumentnummeret avgjør i hvilken rekkefølge dokumentene vises i brukergrensesnittet.

--- a/metadata/M008.yaml
+++ b/metadata/M008.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Identifikasjon av møter som et utvalg har avholdt, viser rekkefølgene
   på møtene
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet, eventuelt også manuelt
 Kommentarer:

--- a/metadata/M010.yaml
+++ b/metadata/M010.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Unik ID for en part
-Forekomster: 0-1
 Gruppe: Identifikasjon
 Kilde: Registreres manuelt når part opprettes
 Kommentarer: Kan være fødselsnummer eller annen personidentifikasjon

--- a/metadata/M011.yaml
+++ b/metadata/M011.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Inngår i *M003 mappeID*. Viser året saksmappen ble opprettet.
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når saksmappen opprettes
 Kommentarer: Se kommentar under *M012 sakssekvensnummer*

--- a/metadata/M012.yaml
+++ b/metadata/M012.yaml
@@ -5,7 +5,6 @@ Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Inngår i *M003 mappeID*. Viser rekkefølgen når saksmappen ble opprettet
   innenfor året.
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når saksmappen opprettes
 Kommentarer: Kombinasjonen saksår og sakssekvensnummer er ikke obligatorisk, men anbefales

--- a/metadata/M013.yaml
+++ b/metadata/M013.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Viser året journalposten ble opprettet
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når journalposten opprettes
 Kommentarer: Kombineres med *M014 journalsekvensnummer*, se kommentar under denne

--- a/metadata/M014.yaml
+++ b/metadata/M014.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Viser rekkefølgen når journalposten ble opprettet under året
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når journalposten opprettes
 Kommentarer: |-

--- a/metadata/M015.yaml
+++ b/metadata/M015.yaml
@@ -6,7 +6,6 @@ Betingelser: Skal normalt ikke endres, men ved flytting til en annen saksmappe k
   denne mappen).
 Datatype: Heltall
 Definisjon: Viser rekkefølgen på journalpostene innenfor saksmappen,.
-Forekomster: '1'
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når journalposten opprettes
 Kommentarer: Er ikke obligatorisk, men anbefales brukt i sakarkiver. Kombineres med

--- a/metadata/M020.yaml
+++ b/metadata/M020.yaml
@@ -6,7 +6,6 @@ Betingelser: Skal normalt ikke kunne endres etter at enheten er lukket, eller do
   arkivert
 Datatype: Tekststreng
 Definisjon: Tittel eller navn på arkivenheten
-Forekomster: '1'
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres manuelt eller hentes automatisk fra innholdet i arkivdokumentet.
   Ja fra klassetittel dersom alle mapper skal ha samme tittel som klassen. Kan også

--- a/metadata/M021.yaml
+++ b/metadata/M021.yaml
@@ -5,7 +5,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Tekstlig beskrivelse av arkivenheten
-Forekomster: 0-1
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres manuelt
 Kommentarer: Tilsvarende attributt finnes ikke i Noark 4 (men noen tabeller hadde

--- a/metadata/M022.yaml
+++ b/metadata/M022.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Nøkkeord eller stikkord som beskriver innholdet i enheten
-Forekomster: 0-M
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres vanligvis ved oppslag fra liste (f.eks. en tesaurus). Kan også
   registreres automatisk på grunnlag av dokumentinnhold eller integrering med fagsystem.

--- a/metadata/M023.yaml
+++ b/metadata/M023.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på organisasjonen som har skapt arkivet
-Forekomster: '1'
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres manuelt ved opprettelsen av arkivet.
 Kommentarer:

--- a/metadata/M024.yaml
+++ b/metadata/M024.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person (eller eventuelt organisasjon) som har forfattet eller
   skapt dokumentet.
-Forekomster: 0-M
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres automatisk av systemet, automatisk fra innholdet i dokumentet eller
   manuelt

--- a/metadata/M025.yaml
+++ b/metadata/M025.yaml
@@ -6,7 +6,6 @@ Betingelser: Obligatorisk i arkivuttrekk dersom tittelen inneholder ord som skal
 Datatype: Tekststreng
 Definisjon: Offentlig tittel på arkivenheten, ord som skal skjermes er fjernet fra
   innholdet i tittelen (erstattet med ******)
-Forekomster: 0-1
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde:
 Kommentarer: I løpende og offentlig journaler skal også offentligTittel være med dersom

--- a/metadata/M050.yaml
+++ b/metadata/M050.yaml
@@ -10,7 +10,6 @@ Betingelser: |-
   Skifte av status kan bare utføres av autoriserte personer.
 Datatype: Tekststreng
 Definisjon: Status til arkivet
-Forekomster: 0-1
 Gruppe: Status
 Kilde: Registreres manuelt når arkivet opprettes eller ved skifte av status.
 Kommentarer:

--- a/metadata/M051.yaml
+++ b/metadata/M051.yaml
@@ -12,7 +12,6 @@ Betingelser: |-
   Skifte av status kan bare utføres av autoriserte personer.
 Datatype: Tekststreng
 Definisjon: Status til den arkivperioden som arkivdelen omfatter
-Forekomster: '1'
 Gruppe: Status
 Kilde: Registreres manuelt når arkivdelen opprettes eller ved skifte av status.
 Kommentarer: Arkivdeler som avleveres skal ha status "Avsluttet periode"

--- a/metadata/M052.yaml
+++ b/metadata/M052.yaml
@@ -11,7 +11,6 @@ Betingelser: |-
   Skifte av status kan bare utføres av autoriserte personer.
 Datatype: Tekststreng
 Definisjon: Status til saksmappen, dvs. hvor langt saksbehandlingen har kommet.
-Forekomster: '1'
 Gruppe: Status
 Kilde: Registreres automatisk gjennom forskjellig saksbehandlings­funksjonalitet,
   eller overstyres manuelt.

--- a/metadata/M053.yaml
+++ b/metadata/M053.yaml
@@ -13,7 +13,6 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Status til journalposten, dvs. om dokumentet er registrert, under behandling
   eller endelig arkivert.
-Forekomster: '1'
 Gruppe: Status
 Kilde: Registreres automatisk gjennom forskjellig saksbehandlings­funksjonalitet,
   eller overstyres manuelt.

--- a/metadata/M054.yaml
+++ b/metadata/M054.yaml
@@ -8,7 +8,6 @@ Betingelser: |-
   - "Dokumentet er ferdigstilt"
 Datatype: Tekststreng
 Definisjon: Status til dokumentet
-Forekomster: '1'
 Gruppe: Status
 Kilde: Kan endres automatisk ved endring i saksstatus eller journalstatus.
 Kommentarer: Dokumentbeskrivelser som avlevers skal ha status "Dokumentet er ferdigstilt".

--- a/metadata/M055.yaml
+++ b/metadata/M055.yaml
@@ -9,7 +9,6 @@ Betingelser: |-
   - "Sendt tilbake til foregående utvalg"
 Datatype: Tekststreng
 Definisjon: Status til møteregistreringen
-Forekomster: 0-1
 Gruppe: Status
 Kilde:
 Kommentarer:

--- a/metadata/M056.yaml
+++ b/metadata/M056.yaml
@@ -8,7 +8,6 @@ Betingelser: |-
   - "Foreldet"
 Datatype: Tekststreng
 Definisjon: Informasjon om presedensen er gjeldende eller foreldet
-Forekomster: 0-1
 Gruppe: Status
 Kilde: Registreres manuelt ved foreldelse
 Kommentarer:

--- a/metadata/M082.yaml
+++ b/metadata/M082.yaml
@@ -11,7 +11,6 @@ Betingelser: |-
   - "Saksframlegg"
 Datatype: Tekststreng
 Definisjon: Navn på type journalpost
-Forekomster: '1'
 Gruppe: Typer
 Kilde: Registreres automatisk av systemet eller manuelt
 Kommentarer: Tilsvarer "Noark dokumenttype" i Noark 4

--- a/metadata/M083.yaml
+++ b/metadata/M083.yaml
@@ -10,7 +10,6 @@ Betingelser: |-
   - "Ordrebekreftelser"
 Datatype: Tekststreng
 Definisjon: Navn på type dokument
-Forekomster: '1'
 Gruppe: Typer
 Kilde: Registreres automatisk av systemet eller manuelt
 Kommentarer:

--- a/metadata/M084.yaml
+++ b/metadata/M084.yaml
@@ -9,7 +9,6 @@ Betingelser: |-
   - "Merknad fra arkivansvarlig"
 Datatype: Tekststreng
 Definisjon: Navn på type merknad
-Forekomster: 0-1
 Gruppe: Typer
 Kilde:
 Kommentarer:

--- a/metadata/M085.yaml
+++ b/metadata/M085.yaml
@@ -10,7 +10,6 @@ Betingelser: |-
   - "Vedlegg til møtesak"
 Datatype: Tekststreng
 Definisjon: Navn på type møteregistrering
-Forekomster: '1'
 Gruppe: Typer
 Kilde:
 Kommentarer:

--- a/metadata/M086.yaml
+++ b/metadata/M086.yaml
@@ -14,7 +14,6 @@ Betingelser: |-
   - "Gårds- og bruksnummer"
 Datatype: Tekststreng
 Definisjon: Type klassifikasjonssystem
-Forekomster: 0-1
 Gruppe: Typer
 Kilde: Registreres manuelt ved opprettelse av *klassifikasjonssystem*
 Kommentarer:

--- a/metadata/M087.yaml
+++ b/metadata/M087.yaml
@@ -12,7 +12,6 @@ Betingelser: |-
   - "Intern mottaker"
 Datatype: Tekststreng
 Definisjon: Type korrespondansepart
-Forekomster: '1'
 Gruppe: Typer
 Kilde: Registreres automatisk knyttet til funksjonalitet i forbindelse med opprettelse
   av journalpost, kan også registreres manuelt

--- a/metadata/M088.yaml
+++ b/metadata/M088.yaml
@@ -10,7 +10,6 @@ Betingelser: |-
   - "Interpellasjon"
 Datatype: Tekststreng
 Definisjon: Navn på type møtesak
-Forekomster: 0-1
 Gruppe: Typer
 Kilde:
 Kommentarer:

--- a/metadata/M089.yaml
+++ b/metadata/M089.yaml
@@ -9,7 +9,6 @@ Betingelser: |-
   - "Sletting av variant med sladdet informasjon"
 Datatype: Tekststreng
 Definisjon: Navn på hvilket objekt som er slettet
-Forekomster: '1'
 Gruppe: Typer
 Kilde:
 Kommentarer: Siste versjon av et dokument skal vanligvis ikke kunne slettes. Sletting

--- a/metadata/M100.yaml
+++ b/metadata/M100.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil saksmappen avsluttes
 Datatype: Dato
 Definisjon: Datoen saken er opprettet
-Forekomster: '1'
 Gruppe: Datoer
 Kilde: Settes automatisk til samme dato som *M600 opprettetDato*
 Kommentarer:

--- a/metadata/M101.yaml
+++ b/metadata/M101.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil arkivering
 Datatype: Dato
 Definisjon: Datoen journalposten er journalført
-Forekomster: '1'
 Gruppe: Datoer
 Kilde: Settes automatisk når journalstatus settes til journalført.
 Kommentarer:

--- a/metadata/M102.yaml
+++ b/metadata/M102.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil mappen avsluttes.
 Datatype: Dato
 Definisjon: Datoen når et utvalgsmøte blir avholdt
-Forekomster: '1'
 Gruppe: Datoer
 Kilde: Registreres manuelt ved opprettelsen av en møtemappe.
 Kommentarer:

--- a/metadata/M103.yaml
+++ b/metadata/M103.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil arkivering
 Datatype: Dato
 Definisjon: Dato som er påført selve dokumentet
-Forekomster: 0-1
 Gruppe: Datoer
 Kilde: Datoen hentes automatisk fra dokumentet, eller registreres manuelt
 Kommentarer: Kan brukes både for inngående, utgående og organinterne dokumenter

--- a/metadata/M104.yaml
+++ b/metadata/M104.yaml
@@ -5,7 +5,6 @@ Betingelser: Skal ikke kunne endres ved automatisk registrering, dato for mottak
   fysiske dokumenter skal kunne endres inntil arkivering
 Datatype: Dato
 Definisjon: Dato et eksternt dokument ble mottatt
-Forekomster: 0-1
 Gruppe: Datoer
 Kilde: Registreres manuelt eller automatisk av systemet ved elektronisk kommunikasjon
 Kommentarer: Merk at mottattDato ikke behøver å være identisk med *M600 opprettetDato*

--- a/metadata/M105.yaml
+++ b/metadata/M105.yaml
@@ -5,7 +5,6 @@ Betingelser: Skal ikke kunne endres ved automatisk registrering, dato for forsen
   av fysiske dokumenter skal kunne endres inntil arkivering
 Datatype: Dato
 Definisjon: Dato et internt produsert dokument ble sendt/ekspedert
-Forekomster: 0-1
 Gruppe: Datoer
 Kilde: Registreres manuelt eller automatisk av systemet ved elektronisk kommunikasjon
 Kommentarer:

--- a/metadata/M106.yaml
+++ b/metadata/M106.yaml
@@ -5,7 +5,6 @@ Betingelser: Utlån skal også kunne registreres etter at en saksmappe er avslut
   eller etter at dokumentene i en journalpost ble arkivert.
 Datatype: Dato
 Definisjon: Dato når en fysisk saksmappe eller journalpost ble utlånt
-Forekomster: 0-1
 Gruppe: Datoer
 Kilde: Registreres manuelt ved utlån
 Kommentarer: Det er ikke spesifisert noen dato for tilbakelevering. Tilbakelevering

--- a/metadata/M107.yaml
+++ b/metadata/M107.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal kunne endres manuelt
 Datatype: Dato
 Definisjon: Dato for starten av en arkivperiode
-Forekomster: 0-1
 Gruppe: Datoer
 Kilde: Settes automatisk til samme dato som *M600 opprettetDato*
 Kommentarer: Det kan tenkes tilfeller hvor startdatoen ikke er identisk med datoen

--- a/metadata/M108.yaml
+++ b/metadata/M108.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal kunne endres manuelt.
 Datatype: Dato
 Definisjon: Dato for slutten av en arkivperiode
-Forekomster: 0-1
 Gruppe: Datoer
 Kilde: Settes automatisk til samme dato som *M602 avsluttetDato*
 Kommentarer: Det kan forekomme tilfeller hvor sluttdatoen ikke er identisk med datoen

--- a/metadata/M109.yaml
+++ b/metadata/M109.yaml
@@ -4,7 +4,6 @@ Avleveres:
 Betingelser:
 Datatype: Dato
 Definisjon: Dato som angir fristen for når et inngående dokument må være besvart
-Forekomster: 0-1
 Gruppe: Datoer
 Kilde: Registreres manuelt
 Kommentarer: Forfallsdato kan være angitt som en betingelse i det inngående dokumentet

--- a/metadata/M110.yaml
+++ b/metadata/M110.yaml
@@ -4,7 +4,6 @@ Avleveres:
 Betingelser:
 Datatype: Dato
 Definisjon: Datoen da offentlighetsvurdering ble foretatt
-Forekomster: 0-1
 Gruppe: Datoer
 Kilde: Registreres automatisk knyttet til funksjonalitet for skjerming
 Kommentarer: Dato for offentlighetsvurdering kan brukes dersom inngående dokumenter

--- a/metadata/M111.yaml
+++ b/metadata/M111.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Dato
 Definisjon: Datoen på presedensen
-Forekomster: '1'
 Gruppe: Datoer
 Kilde: Registreres manuelt ved opprettelse av presedens, men bør også kunne hentes
   automatisk fra *M103 dokumentetsDato* på journalposten presedensen opprettes på.

--- a/metadata/M112.yaml
+++ b/metadata/M112.yaml
@@ -5,7 +5,6 @@ Avleveres: A
 Betingelser: Startdato skal selekteres på *M101 journaldato*
 Datatype: Dato
 Definisjon: Startdato for journalutskriftene som inngår i avleveringspakken.
-Forekomster: '1'
 Gruppe: Datoer
 Kilde: Registreres når avleveringspakken produseres
 Kommentarer: Startdatoen vil vanligvis være identisk med *M107 arkivperiodeStartdato*

--- a/metadata/M113.yaml
+++ b/metadata/M113.yaml
@@ -5,7 +5,6 @@ Avleveres: A
 Betingelser: Sluttdato skal selekteres på *M101 journaldato*
 Datatype: Dato
 Definisjon: Sluttdato for journalutskriftene som inngår i avleveringspakken.
-Forekomster: '1'
 Gruppe: Datoer
 Kilde: Registreres når avleveringspakken produseres
 Kommentarer: Sluttdatoen vil vanligvis være identisk med *M108 arkivperiodeSluttdato*

--- a/metadata/M202.yaml
+++ b/metadata/M202.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: systemID
 Definisjon: Referanse til den arkivdelen som er forløper for denne arkivdelen, dvs.
   inneholder forrige arkivperiode.
-Forekomster: 0-1
 Gruppe: Referanser
 Kilde: Registreres automatisk når arkivdelen som er arvtaker opprettes
 Kommentarer:

--- a/metadata/M203.yaml
+++ b/metadata/M203.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: systemID
 Definisjon: Referanse til den arkivdelen som er arvtaker for denne arkivdelen, dvs.
   inneholder neste arkivperiode.
-Forekomster: 0-1
 Gruppe: Referanser
 Kilde: Registreres automatisk når det opprettes en arkivdel som defineres som arvtaker
   til en eksisterende arkivdel

--- a/metadata/M208.yaml
+++ b/metadata/M208.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til arkivdelen som denne arkivenheten er tilknyttet
-Forekomster: 0-M
 Gruppe: Referanser
 Kilde: Registreres automatisk, kan overstyres manuelt
 Kommentarer: 'Alle mapper skal ha referanse til arkivdel (selv om tilhørigheten til

--- a/metadata/M209.yaml
+++ b/metadata/M209.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: systemID
 Definisjon: Referanse til sekundærklassifikasjon. Kan også referere til flere enn
   én sekundær klassifikasjon (tertiærklassifikasjon osv.)
-Forekomster: 0-M
 Gruppe: Referanser
 Kilde: Registreres automatisk ved klassifikasjon
 Kommentarer: Kan også brukes for å bygge opp mangefasettert klassifikasjon og kommunenes

--- a/metadata/M210.yaml
+++ b/metadata/M210.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse til en *mappe* fra en annen *mappe* eller *registrering*
-Forekomster: 0-1
 Gruppe: Referanser
 Kilde: Registreres automatisk når kryssreferanse opprettes
 Kommentarer:

--- a/metadata/M212.yaml
+++ b/metadata/M212.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse til en *registrering* fra en annen *registrering* eller
   *mappe*
-Forekomster: 0-1
 Gruppe: Referanser
 Kilde: Registreres automatisk når en kryssreferanse opprettes
 Kommentarer:

--- a/metadata/M215.yaml
+++ b/metadata/M215.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til en eller flere journalposter som avskriver denne journalposten
-Forekomster: 0-1
 Gruppe: Referanser
 Kilde: Registreres manuelt eller automatisk ved avskrivning
 Kommentarer:

--- a/metadata/M217.yaml
+++ b/metadata/M217.yaml
@@ -8,7 +8,6 @@ Betingelser: |-
   - "Vedlegg"
 Datatype: Tekststreng
 Definisjon: Angivelse av hvilken "rolle" dokumentet har i forhold til registreringen
-Forekomster: '1'
 Gruppe: Referanser
 Kilde: Registreres automatisk eller manuelt når et dokument blir tilknyttet en registrering
 Kommentarer:

--- a/metadata/M218.yaml
+++ b/metadata/M218.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til filen som inneholder det elektroniske dokumentet som dokumentobjektet
   beskriver
-Forekomster: '1'
 Gruppe: Referanser
 Kilde: Registreres automatisk når et dokument tilknyttes en registrering, når det
   arkiveres flere versjoner av et dokument, når det lages en egen variant av dokumentet

--- a/metadata/M219.yaml
+++ b/metadata/M219.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til en annen klasse
-Forekomster: 0-1
 Gruppe: Referanser
 Kilde: Registreres vanligvis manuelt når klassifikasjonssystemet opprettes
 Kommentarer: Kryssreferansen kan gå til en eller flere klasser innenfor samme klassifikasjonssystem,

--- a/metadata/M221.yaml
+++ b/metadata/M221.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til forrige utvalgsmøte
-Forekomster: 0-1
 Gruppe: Referanser
 Kilde: Registreres manuelt
 Kommentarer: Kan brukes dersom et møte går over flere dager

--- a/metadata/M222.yaml
+++ b/metadata/M222.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til neste utvalgsmøte
-Forekomster: 0-1
 Gruppe: Referanser
 Kilde: Registreres manuelt
 Kommentarer: Kan brukes dersom et møte går over flere dager

--- a/metadata/M223.yaml
+++ b/metadata/M223.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til en annen møteregistrering
-Forekomster: 0-M
 Gruppe: Referanser
 Kilde:
 Kommentarer: Kan brukes for å knytte sammen dokumenter som tilhører samme "møtesak"

--- a/metadata/M224.yaml
+++ b/metadata/M224.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse fra en annen møteregistrering
-Forekomster: 0-M
 Gruppe: Referanser
 Kilde:
 Kommentarer: Kan brukes for å knytte sammen dokumenter som tilhører samme "møtesak"

--- a/metadata/M300.yaml
+++ b/metadata/M300.yaml
@@ -10,7 +10,6 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av om arkivenheten inneholder fysiske dokumenter, elektroniske
   dokumenter eller en blanding av fysiske og elektroniske dokumenter
-Forekomster: 0-1
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Arves fra overordnet nivå, kan overstyres manuelt
 Kommentarer: Obligatorisk ved blanding av fysisk og elektronisk arkiv. Er hele arkivet

--- a/metadata/M301.yaml
+++ b/metadata/M301.yaml
@@ -6,7 +6,6 @@ Datatype: Tekststreng
 Definisjon: Stedet hvor de fysiske dokumentene oppbevares. Kan være angivelse av rom,
   hylle, skap osv. Overordnede arkivdeler (f.eks. en arkivdel) kan oppbevares på flere
   steder.
-Forekomster: 0-1
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Arves fra overordnet nivå, kan overstyres manuelt
 Kommentarer: Fysiske dokumenters plassering skal ellers gå fram av arkivstrukturen.

--- a/metadata/M302.yaml
+++ b/metadata/M302.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på virksomhet eller person som er part
-Forekomster: '1'
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt eller automatisk fra fagsystem
 Kommentarer:

--- a/metadata/M303.yaml
+++ b/metadata/M303.yaml
@@ -10,7 +10,6 @@ Betingelser: |-
   - Advokat
 Datatype: Tekststreng
 Definisjon: Angivelse av rollen til parten
-Forekomster: '1'
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt eller automatisk fra fagsystem
 Kommentarer:

--- a/metadata/M304.yaml
+++ b/metadata/M304.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall fysiske vedlegg til et fysisk hoveddokument
-Forekomster: 0-1
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt
 Kommentarer:

--- a/metadata/M305.yaml
+++ b/metadata/M305.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på avdeling, kontor eller annen administrativ enhet som har ansvaret
   for saksbehandlingen.
-Forekomster: '1'
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres automatisk f.eks. på grunnlag av innlogget bruker, kan overstyres
 Kommentarer: Merk at på journalpostnivå grupperes *administrativEnhet* sammen med

--- a/metadata/M306.yaml
+++ b/metadata/M306.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som er saksansvarlig
-Forekomster: '1'
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres automatisk på grunnlag av innlogget bruker eller annen saksbehandlingsfunksjonalitet
   (f.eks. saksfordeling), kan overstyres manuelt

--- a/metadata/M307.yaml
+++ b/metadata/M307.yaml
@@ -5,7 +5,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som er saksbehandler
-Forekomster: '1'
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres automatisk på grunnlag av innlogget bruker eller annen saksbehandlingsfunksjonalitet
   (f.eks. saksfordeling), kan overstyres manuelt.

--- a/metadata/M308.yaml
+++ b/metadata/M308.yaml
@@ -8,7 +8,6 @@ Datatype: Tekststreng
 Definisjon: Navn på enhet som har det arkivmessige ansvaret for kvalitetssikring av
   arkivdanningen, og eventuelt registrering (journalføring) og arkivering av fysiske
   dokumenter
-Forekomster: 0-1
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres automatisk på grunnlag av innlogget bruker, kan overstyres manuelt
 Kommentarer:

--- a/metadata/M309.yaml
+++ b/metadata/M309.yaml
@@ -5,7 +5,6 @@ Betingelser: Utlån skal også kunne registreres etter at en saksmappe er avslut
   eller at dokumentene i en journalpost ble arkivert
 Datatype: Tekststreng
 Definisjon: Navnet på person som har lånt en fysisk saksmappe
-Forekomster: 0-1
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt ved utlån
 Kommentarer:

--- a/metadata/M310.yaml
+++ b/metadata/M310.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Merknad fra saksbehandler, leder eller arkivpersonale.
-Forekomster: '1'
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt
 Kommentarer: Merknaden bør gjelde selve saksbehandlingen eller forhold rundt arkiveringen

--- a/metadata/M311.yaml
+++ b/metadata/M311.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Lovparagrafen som saken eller journalposten danner presedens for
-Forekomster: 0-1
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt ved opprettelse av presedens
 Kommentarer:

--- a/metadata/M312.yaml
+++ b/metadata/M312.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: En argumentkilde som brukes til å løse rettslige problemer. En retts­anvender
   som skal ta stilling til et juridisk spørsmål, vil ta utgangspunkt i en rettskildefaktor.
-Forekomster: '1'
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt ved opprettelse av presedens
 Kommentarer: En rettskildefaktor kan være en lov- eller forskriftstekst, lovforarbeider,

--- a/metadata/M313.yaml
+++ b/metadata/M313.yaml
@@ -6,7 +6,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Beskrivelse av kriteriene som er brukt ved seleksjon av journalrapportenes
   innhold.
-Forekomster: 0-1
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde:
 Kommentarer: Både løpende og offentlig journal er i utgangspunktet selektert etter

--- a/metadata/M370.yaml
+++ b/metadata/M370.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på utvalget som avholdt møte
-Forekomster: '1'
 Gruppe: Møtebehandling
 Kilde: Registreres manuelt ved opprettelsen av møtemappen
 Kommentarer:

--- a/metadata/M371.yaml
+++ b/metadata/M371.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Sted hvor møtet ble avholdt
-Forekomster: 0-1
 Gruppe: Møtebehandling
 Kilde: Registreres manuelt ved opprettelsen av møtemappen
 Kommentarer:

--- a/metadata/M372.yaml
+++ b/metadata/M372.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som var til stedet på møtet
-Forekomster: '1'
 Gruppe: Møtebehandling
 Kilde: Registreres manuelt ved opprettelsen av møtemappen, kan eventuelt også hentes
   automatisk fra f.eks. møteinnkalling

--- a/metadata/M373.yaml
+++ b/metadata/M373.yaml
@@ -8,7 +8,6 @@ Betingelser: |-
   - "Referent"
 Datatype: Tekststreng
 Definisjon: Funksjon eller rolle til personen som deltok på møtet
-Forekomster: 0-1
 Gruppe: Møtebehandling
 Kilde:
 Kommentarer:

--- a/metadata/M400.yaml
+++ b/metadata/M400.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person eller organisasjon som er avsender eller mottaker av dokumentet
-Forekomster: '1'
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer: Navn på korrespondansepart forekommer én gang innenfor objektet korrespondansepart,

--- a/metadata/M406.yaml
+++ b/metadata/M406.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Postadressen til en avsender /mottaker eller part
-Forekomster: 0-M
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer: En postadresse kan angis som flere elementer ("adresselinjer"), noe som

--- a/metadata/M407.yaml
+++ b/metadata/M407.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Postnummeret til en avsender /mottaker eller part
-Forekomster: 0-1
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:

--- a/metadata/M408.yaml
+++ b/metadata/M408.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Poststedet til en avsender/mottaker eller part
-Forekomster: 0-1
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:

--- a/metadata/M409.yaml
+++ b/metadata/M409.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Land dersom adressen er i utlandet
-Forekomster: 0-1
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:

--- a/metadata/M410.yaml
+++ b/metadata/M410.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: E-postadressen til en avsender/mottaker eller part
-Forekomster: 0-1
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:

--- a/metadata/M411.yaml
+++ b/metadata/M411.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Telefonnummeret til en avsender/mottaker eller part
-Forekomster: 0-M
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk
 Kommentarer:

--- a/metadata/M412.yaml
+++ b/metadata/M412.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Kontaktperson hos en organisasjon som er avsender eller mottaker, eller
   part
-Forekomster: 0-1
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk
 Kommentarer:

--- a/metadata/M450.yaml
+++ b/metadata/M450.yaml
@@ -9,7 +9,6 @@ Betingelser: |-
   - "Vurderes senere"
 Datatype: Tekststreng
 Definisjon: Handling som skal utføres ved bevaringstidens slutt.
-Forekomster: '1'
 Gruppe: Bevaring og kassasjon
 Kilde: Registreres manuelt ved opprettelse av *arkivdel* eller *klasse*. Arves til
   underliggende enheter, men kan endres manuelt.

--- a/metadata/M451.yaml
+++ b/metadata/M451.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall år dokumentene som tilhører denne arkivdelen skal bevares.
-Forekomster: '1'
 Gruppe: Bevaring og kassasjon
 Kilde: Registreres manuelt ved opprettelse av *arkivdel* eller *klasse*. Arves til
   underliggende enheter, men kan endres manuelt.

--- a/metadata/M452.yaml
+++ b/metadata/M452.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Dato
 Definisjon: Dato for når dokumentene som tilhører denne arkivenheten skal kunne kasseres,
   eller vurderes for bevaring og kassasjon på ny
-Forekomster: '1'
 Gruppe: Bevaring og kassasjon
 Kilde: Datoen beregnes automatisk på grunnlag av *M451 Bevaringstid*, eller registreres
   manuelt

--- a/metadata/M453.yaml
+++ b/metadata/M453.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Angivelse av hjemmel for kassasjon
-Forekomster: 0-1
 Gruppe: Bevaring og kassasjon
 Kilde: Registreres manuelt ved opprettelse av *arkivdel* eller *klasse*. Arves til
   underliggende enheter, men kan endres manuelt

--- a/metadata/M500.yaml
+++ b/metadata/M500.yaml
@@ -13,7 +13,6 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av at dokumentene som tilhører arkivenheten ikke er offentlig
   tilgjengelig i henhold til offentlighetsloven eller av en annen grunn
-Forekomster: 0-1
 Gruppe: Skjerming og gradering
 Kilde: Registreres manuelt ved valg fra liste, kan også registres automatisk
 Kommentarer:

--- a/metadata/M501.yaml
+++ b/metadata/M501.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Henvisning til hjemmel (paragraf) i offentlighetsloven, sikkerhetsloven
   eller beskyttelsesinstruksen
-Forekomster: 0-1
 Gruppe: Skjerming og gradering
 Kilde: Registreres automatisk på grunnlag av valgt tilgangskode, kan overstyres manuelt
 Kommentarer:

--- a/metadata/M502.yaml
+++ b/metadata/M502.yaml
@@ -18,7 +18,6 @@ Betingelser: |-
   - "Midlertidig skjerming"
 Datatype: Tekststreng
 Definisjon: Angivelse av hvilke metadataelementer som skal skjermes.
-Forekomster: 0-1
 Gruppe: Skjerming og gradering
 Kilde: Registreres manuelt ved valg fra liste eller annen funksjonalitet, kan også
   registreres automatisk

--- a/metadata/M503.yaml
+++ b/metadata/M503.yaml
@@ -8,7 +8,6 @@ Betingelser: |-
   - "Skjerming av deler av dokumentet"
 Datatype: Tekststreng
 Definisjon: Angivelse av at hele dokumentet eller deler av det må skjermes.
-Forekomster: 0-1
 Gruppe: Skjerming og gradering
 Kilde: Registreres manuelt ved valg fra liste eller annen funksjonalitet, kan også
   registreres automatisk

--- a/metadata/M504.yaml
+++ b/metadata/M504.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall år skjermingen skal opprettholdes.
-Forekomster: 0-1
 Gruppe: Skjerming og gradering
 Kilde: Registreres automatisk knyttet til valg av tilgangskode, kan registreres manuelt.
 Kommentarer: Tidspunktet for når skjermingsvarigheten starter å løpe, vil vanligvis

--- a/metadata/M505.yaml
+++ b/metadata/M505.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Dato
 Definisjon: Datoen skjermingen skal oppheves.
-Forekomster: 0-1
 Gruppe: Skjerming og gradering
 Kilde: Datoen beregnes automatisk på grunnlag av *M504 skjermingsvarighet*
 Kommentarer:

--- a/metadata/M506.yaml
+++ b/metadata/M506.yaml
@@ -15,7 +15,6 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av at dokumentene er gradert i henhold til sikkerhetsloven eller
   beskyttelsesinstruksen.
-Forekomster: 0-1
 Gruppe: Skjerming og gradering
 Kilde: Registreres manuelt ved valg fra liste, kan også registres automatisk
 Kommentarer: Dokumenter gradert "Strengt hemmelig", "Hemmelig", "Konfidensielt" og

--- a/metadata/M507.yaml
+++ b/metadata/M507.yaml
@@ -11,7 +11,6 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av hvilket sikkerhetsnivå som ble brukt ved forsendelse og mottak
   av elektroniske dokumenter
-Forekomster: '1'
 Gruppe: Skjerming og gradering
 Kilde: Registreres automatisk knyttet til funksjonalitet for elektronisk signatur
 Kommentarer:

--- a/metadata/M508.yaml
+++ b/metadata/M508.yaml
@@ -9,7 +9,6 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av om et dokument er mottatt med elektronisk signatur, og om
   signaturen er verifisert.
-Forekomster: '1'
 Gruppe: Skjerming og gradering
 Kilde: Registreres automatisk knyttet til funksjonalitet for elektronisk signatur
 Kommentarer: Dersom signaturen er verifisert, skal det logges hvem som verifiserte

--- a/metadata/M580.yaml
+++ b/metadata/M580.yaml
@@ -4,7 +4,6 @@ Avleveres:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på bruker av en Noark 5-løsning
-Forekomster: '1'
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer: Navn på bruker vil registreres mange steder i arkivstrukturen, f.eks.

--- a/metadata/M581.yaml
+++ b/metadata/M581.yaml
@@ -10,7 +10,6 @@ Betingelser: |-
   - "Saksbehandler"
 Datatype: Tekststreng
 Definisjon: Rollen til en bruker av en Noark 5-løsning.
-Forekomster: '1'
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer:

--- a/metadata/M582.yaml
+++ b/metadata/M582.yaml
@@ -8,7 +8,6 @@ Betingelser: |-
   - "Sluttet"
 Datatype: Tekststreng
 Definisjon: Status til en bruker av en Noark 5-løsning.
-Forekomster: 0-1
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer:

--- a/metadata/M583.yaml
+++ b/metadata/M583.yaml
@@ -4,7 +4,6 @@ Avleveres:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på administrativ enhet
-Forekomster: '1'
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer: Navn på administrativ enhet vil registreres flere steder i arkivstrukturen,

--- a/metadata/M584.yaml
+++ b/metadata/M584.yaml
@@ -8,7 +8,6 @@ Betingelser: |-
   - "Passiv enhet"
 Datatype: Tekststreng
 Definisjon: Status til den administrative enheten
-Forekomster: 0-1
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer:

--- a/metadata/M585.yaml
+++ b/metadata/M585.yaml
@@ -4,7 +4,6 @@ Avleveres:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til enhet som er direkte overordnet denne enheten
-Forekomster: 0-1
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer:

--- a/metadata/M600.yaml
+++ b/metadata/M600.yaml
@@ -5,7 +5,6 @@ Avleveres:
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten ble opprettet/registrert
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:

--- a/metadata/M601.yaml
+++ b/metadata/M601.yaml
@@ -5,7 +5,6 @@ Avleveres:
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Navn på person som opprettet/registrerte arkivenheten
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:

--- a/metadata/M602.yaml
+++ b/metadata/M602.yaml
@@ -4,7 +4,6 @@ Avleveres:
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivdelen er avsluttet.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten ble avsluttet/lukket
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet når enheten avsluttes
 Kommentarer:

--- a/metadata/M603.yaml
+++ b/metadata/M603.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivenheten er avsluttet.
 Datatype: Tekststreng
 Definisjon: Navn på person som avsluttet/lukket arkivenheten
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:

--- a/metadata/M604.yaml
+++ b/metadata/M604.yaml
@@ -5,7 +5,6 @@ Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når alle dokumentene som er tilknyttet registreringen
   ble arkivert
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved utførelse av en funksjon som markerer at dokumentene
   er arkivert. For journalposter kan dette knyttes til endring av journalstatus.

--- a/metadata/M605.yaml
+++ b/metadata/M605.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som arkiverte dokumentet og frøs det for all videre redigering
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved utførelse av en funksjon som markerer at dokumentene
   er arkivert. For journalposter kan dette knyttes til endring av journalstatus.

--- a/metadata/M609.yaml
+++ b/metadata/M609.yaml
@@ -5,7 +5,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Antall journalposter i rapporten
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved produksjon av avleveringsuttrekk
 Kommentarer:

--- a/metadata/M611.yaml
+++ b/metadata/M611.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når merknaden ble registrert
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet
 Kommentarer:

--- a/metadata/M612.yaml
+++ b/metadata/M612.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har registrert merknaden
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet
 Kommentarer:

--- a/metadata/M613.yaml
+++ b/metadata/M613.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble slettet
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når en tidligere versjon eller en variant av et dokument
   slettes.

--- a/metadata/M614.yaml
+++ b/metadata/M614.yaml
@@ -5,7 +5,6 @@ Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har utført en kontrollert kassasjon av dokumenter,
   eller sletting av versjoner, formater og varianter.
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når et dokument blir slettet
 Kommentarer: Sletting må ikke blandes sammen med kassasjon.

--- a/metadata/M615.yaml
+++ b/metadata/M615.yaml
@@ -5,7 +5,6 @@ Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett for når et dokument ble konvertert fra et format til
   et annet
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved konvertering
 Kommentarer:

--- a/metadata/M616.yaml
+++ b/metadata/M616.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Person eller system som har foretatt konverteringen
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved konvertering
 Kommentarer:

--- a/metadata/M617.yaml
+++ b/metadata/M617.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato
 Definisjon: Dato et dokument ble avskrevet
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk nå avskrivning foretas
 Kommentarer:

--- a/metadata/M618.yaml
+++ b/metadata/M618.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har foretatt avskrivning
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når avskrivning foretas
 Kommentarer:

--- a/metadata/M619.yaml
+++ b/metadata/M619.yaml
@@ -11,7 +11,6 @@ Betingelser: |-
   - "Tatt til orientering"
 Datatype: Tekststreng
 Definisjon: Måten en journalpost har blitt avskrevet på
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når konvertering utføres.
 Kommentarer:

--- a/metadata/M620.yaml
+++ b/metadata/M620.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Datoen et dokument ble knyttet til en registrering
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk nå tilknytning foretas
 Kommentarer:

--- a/metadata/M621.yaml
+++ b/metadata/M621.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som knyttet et dokument til en registrering
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når tilknytning foretas
 Kommentarer:

--- a/metadata/M622.yaml
+++ b/metadata/M622.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato en elektronisk signatur ble verifisert
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når verifisering utføres
 Kommentarer:

--- a/metadata/M623.yaml
+++ b/metadata/M623.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har verifisert en elektronisk signatur
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når verifisering utføres
 Kommentarer:

--- a/metadata/M624.yaml
+++ b/metadata/M624.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble gradert
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved gradering
 Kommentarer:

--- a/metadata/M625.yaml
+++ b/metadata/M625.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som foretok graderingen
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved gradering
 Kommentarer:

--- a/metadata/M626.yaml
+++ b/metadata/M626.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble nedgradert
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved nedgradering
 Kommentarer:

--- a/metadata/M627.yaml
+++ b/metadata/M627.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som foretok nedgraderingen
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved nedgradering
 Kommentarer:

--- a/metadata/M628.yaml
+++ b/metadata/M628.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett for når presedensen er godkjent
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk dersom det finnes funksjonalitet for å godkjenne presedenser
 Kommentarer:

--- a/metadata/M629.yaml
+++ b/metadata/M629.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som har godkjent presedensen
-Forekomster: 0-1
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk dersom det finnes funksjonalitet for å godkjenne presedenser
 Kommentarer:

--- a/metadata/M630.yaml
+++ b/metadata/M630.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når kassasjonen ble utført
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når kassasjon utføres
 Kommentarer:

--- a/metadata/M631.yaml
+++ b/metadata/M631.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har utført kassasjonen
-Forekomster: '1'
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når kassasjon utføres
 Kommentarer:

--- a/metadata/M660.yaml
+++ b/metadata/M660.yaml
@@ -6,7 +6,6 @@ Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke 
 Datatype: Tekststreng
 Definisjon: Person som har mottatt for godkjennelse et dokument som har vært sendt
   på flyt
-Forekomster: '1'
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:

--- a/metadata/M661.yaml
+++ b/metadata/M661.yaml
@@ -5,7 +5,6 @@ Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke 
   endres.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett et dokument på flyt ble mottatt
-Forekomster: '1'
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:

--- a/metadata/M662.yaml
+++ b/metadata/M662.yaml
@@ -5,7 +5,6 @@ Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke 
   endres.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett et dokument på flyt ble sendt videre
-Forekomster: '1'
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:

--- a/metadata/M663.yaml
+++ b/metadata/M663.yaml
@@ -9,7 +9,6 @@ Betingelser: |-
   - "Sendt tilbake til saksbehandler med kommentarer"
 Datatype: Tekststreng
 Definisjon: Godkjennelse/ikke godkjennelse av dokumentet som er sendt på flyt
-Forekomster: '1'
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:

--- a/metadata/M664.yaml
+++ b/metadata/M664.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Merknad eller kommentar til et dokument som er sendt på flyt
-Forekomster: 0-1
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres manuelt
 Kommentarer:

--- a/metadata/M665.yaml
+++ b/metadata/M665.yaml
@@ -5,7 +5,6 @@ Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke 
   endres.
 Datatype: Tekststreng
 Definisjon: Person som har sendt et dokument på flyt
-Forekomster: '1'
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:

--- a/metadata/M680.yaml
+++ b/metadata/M680.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til arkivenheten (systemID) som inneholder metadata­elementet
   som ble endret
-Forekomster: '1'
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:

--- a/metadata/M681.yaml
+++ b/metadata/M681.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navnet på metadataelementet som ble endret
-Forekomster: '1'
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:

--- a/metadata/M682.yaml
+++ b/metadata/M682.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et metadataelement ble endret
-Forekomster: '1'
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:

--- a/metadata/M683.yaml
+++ b/metadata/M683.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som foretok en endring av metadata
-Forekomster: '1'
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:

--- a/metadata/M684.yaml
+++ b/metadata/M684.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Innholdet i metadataelementet før det ble endret
-Forekomster: '1'
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:

--- a/metadata/M685.yaml
+++ b/metadata/M685.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Det nye innholdet i metadataelementet
-Forekomster: '1'
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:

--- a/metadata/M700.yaml
+++ b/metadata/M700.yaml
@@ -11,7 +11,6 @@ Betingelser: |-
   Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Angivelse av hvilken variant et dokument forekommer i
-Forekomster: '1'
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk når dokumentet arkiveres
 Kommentarer:

--- a/metadata/M701.yaml
+++ b/metadata/M701.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Dokumentets format
-Forekomster: '1'
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk når dokumentet arkiveres
 Kommentarer: Faste verdier bestemmes senere

--- a/metadata/M702.yaml
+++ b/metadata/M702.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Nærmere spesifikasjon av dokuments format, f.eks. informasjon om komprimering
-Forekomster: 0-1
 Gruppe: Tekniske metadata
 Kilde:
 Kommentarer:

--- a/metadata/M705.yaml
+++ b/metadata/M705.yaml
@@ -5,7 +5,6 @@ Betingelser: Kan ikke endres. Sjekksummen skal være heksadesimal uten noen form
 Datatype: Tekststreng
 Definisjon: En verdi som beregnes ut fra innholdet i dokumentet, og som dermed gir
   integritetssikring til dokumentets innhold
-Forekomster: '1'
 Gruppe: Tekniske metadata
 Kilde: Påføres automatisk i forbindelse med eksport for avlevering
 Kommentarer:

--- a/metadata/M706.yaml
+++ b/metadata/M706.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres. Algoritmen som skal brukes inntil videre er SHA256.
 Datatype: Tekststreng
 Definisjon: Algoritmen som er brukt for å beregne sjekksummen
-Forekomster: '1'
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk i forbindelse med eksport for avlevering
 Kommentarer:

--- a/metadata/M707.yaml
+++ b/metadata/M707.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Størrelsen på fila i antall bytes oppgitt med desimaltall
-Forekomster: '1'
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk i forbindelse med eksport for avlevering
 Kommentarer:

--- a/metadata/M711.yaml
+++ b/metadata/M711.yaml
@@ -5,7 +5,6 @@ Betingelser:
 Datatype: Vilkårlig struktur
 Definisjon: Et overordnet metadataelement som kan inneholde egendefinerte metadata.
   Disse metadataene må da være spesifisert i et eller flere XML-skjema.
-Forekomster: 0-1
 Gruppe: Tekniske metadata
 Kilde:
 Kommentarer:

--- a/metadata/M712.yaml
+++ b/metadata/M712.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Formatet dokumentet hadde før det ble konvertert
-Forekomster: '1'
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk ved konvertering
 Kommentarer: Dette vil vanligvis være produksjonsformatet, men kan også være et annet

--- a/metadata/M713.yaml
+++ b/metadata/M713.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Formatet dokumentet fikk etter konvertering
-Forekomster: '1'
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk ved konvertering
 Kommentarer: Faste verdier bestemmes senere

--- a/metadata/M714.yaml
+++ b/metadata/M714.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på det IT-verktøyet som ble brukt til å foreta konverteringen
-Forekomster: 0-1
 Gruppe: Tekniske metadata
 Kilde:
 Kommentarer:

--- a/metadata/M715.yaml
+++ b/metadata/M715.yaml
@@ -4,7 +4,6 @@ Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Kommentarer til konverteringen
-Forekomster: 0-1
 Gruppe: Tekniske metadata
 Kilde:
 Kommentarer:

--- a/scripts/metadata-xml2yaml
+++ b/scripts/metadata-xml2yaml
@@ -34,10 +34,6 @@ class Converter(object):
                 if 'Obligatorisk' == field:
                     field = 'Obligatorisk/valgfri'
                 value = line.text
-                if 'Forekomster' == field and 'En' == value:
-                    value = 1
-                if 'Forekomster' == field and 'Mange' == value:
-                    value = '1-M'
                 entry[field] = value
             def represent_str(self, data):
                 tag = None

--- a/scripts/metadata2rst
+++ b/scripts/metadata2rst
@@ -9,7 +9,7 @@ import yaml
 def main():
     retval = 0
     required = ('Nr', 'Navn', 'Datatype', 'Avleveres', 'Obligatorisk/valgfri',
-                'Forekomster', 'Definisjon', 'Arkivenhet', 'Kilde')
+                'Definisjon', 'Arkivenhet', 'Kilde')
     optional = ('Noark 4', 'Arv', 'Betingelser', 'Kommentarer',)
     parser = argparse.ArgumentParser()
     parser.add_argument("yamlfile", nargs='+',
@@ -58,7 +58,7 @@ def main():
             print("By %s" % unit)
             for number in byunit[unit]:
                 line = []
-                for f in ('Nr', 'Navn', 'Forekomster', 'Avleveres', 'Datatype'):
+                for f in ('Nr', 'Navn', 'Avleveres', 'Datatype'):
                     line.append(byunit[unit][number][f])
                 print(line)
             print()
@@ -66,7 +66,6 @@ def main():
         fields = ('Nr',
                   'Navn',
                   'Obligatorisk/valgfri',
-                  'Forekomster',
                   'Definisjon',
                   'Arkivenhet',
                   'Kilde',
@@ -80,14 +79,6 @@ Katalogoppføringer
 
 """)
         def mapvalue(field, value):
-            if 'Forekomster' == field:
-                value = {
-                    1: 'En',
-                    '1': 'En',
-                    '0-1': 'En',
-                    '0-M': 'Mange',
-                    '1-M': 'Mange',
-                }[value]
             if field in boldvalue:
                 value = '**%s**' % value
             return value

--- a/scripts/metadata2xsd
+++ b/scripts/metadata2xsd
@@ -56,7 +56,7 @@ class XMLFile(object):
 def main():
     retval = 0
     required = ('Nr', 'Navn', 'Datatype', 'Avleveres', 'Obligatorisk/valgfri',
-                'Forekomster', 'Definisjon', 'Arkivenhet', 'Kilde')
+                'Definisjon', 'Arkivenhet', 'Kilde')
     optional = ('Noark 4', 'Arv', 'Betingelser', 'Kommentarer',)
     parser = argparse.ArgumentParser()
     parser.add_argument("yamlfile", nargs='+',

--- a/scripts/metadatarst2yaml
+++ b/scripts/metadatarst2yaml
@@ -61,11 +61,6 @@ class MetadataRstVisitor(docutils.nodes.NodeVisitor):
                 .replace('<emphasis>', '*') \
                 .replace('</emphasis>', '*')
             value = value.strip()
-            if u'Forekomster' == field:
-                if u'En' == value:
-                    value = 1
-                elif u'Mange' == value:
-                    value = '1-M'
             self.entry[field] = value
 
     def depart_table(self, node: docutils.nodes.Node) -> None:
@@ -73,7 +68,7 @@ class MetadataRstVisitor(docutils.nodes.NodeVisitor):
         #print(self.entry)
 
         if self.entry['Nr'] in self.metadata:
-            for field in ('Avleveres', 'Datatype', 'Forekomster'):
+            for field in ('Avleveres', 'Datatype'):
                 self.entry[field] = self.metadata[self.entry['Nr']][field]
         else:
             for field in ('Avleveres', 'Datatype'):
@@ -130,11 +125,10 @@ class MetadataObjSortRstVisitor(docutils.nodes.NodeVisitor):
         info = {
             'Entitet': self.lasttitle.replace('Metadata for ', ''),
             'Navn': node.children[1].astext().strip(),
-            'Forekomster': node.children[3].astext().strip(),
             'Avleveres': node.children[4].astext().strip(),
             'Datatype': node.children[5].astext().strip(),
         }
-        for attribute in ('Avleveres', 'Datatype', 'Forekomster'):
+        for attribute in ('Avleveres', 'Datatype'):
             if '' == info[attribute]:
                 info[attribute] = None
         # Transform 'Tekststreng (filkatalogstruktur + filnavn)' to
@@ -146,7 +140,7 @@ class MetadataObjSortRstVisitor(docutils.nodes.NodeVisitor):
             info['Datatype'] = info['Datatype'].split('.')[1]
 
         if field in self.metadata:
-            for attribute in ('Avleveres', 'Datatype', 'Forekomster'):
+            for attribute in ('Avleveres', 'Datatype'):
                 if self.metadata[field][attribute] != info[attribute]:
                     print('error: field %s %s change %s from %s in %s to %s in %s' % (
                         field,


### PR DESCRIPTION
Forekost vil variere etter hvor katalogppføringene er brukt, så det er misvisende å ha feltet med i metadatakatalogen.  Det holder at forekostinformasjon vises i tillegg B, dvs. metadata gruppert på objekt.

Relatert til #24.