### PR TITLE
Fjernet obligatorisk/valgfri-informasjon fra metadatakatalog-oppførin…

### DIFF
--- a/metadata/M001.yaml
+++ b/metadata/M001.yaml
@@ -14,4 +14,3 @@ Kommentarer: Alle referanser fra en arkivenhet til en annen skal peke til arkive
   f.eks. mellom to arkivperioder som avleveres på forskjellig tidspunkt.
 Navn: systemID
 Nr: M001
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M002.yaml
+++ b/metadata/M002.yaml
@@ -17,4 +17,3 @@ Kommentarer: Ulike klassifikasjonssystemer innenfor samme arkivsystem kan inneho
   er identisk med begrepene ordningsverdi og arkivkode i Noark 4.
 Navn: klasseID
 Nr: M002
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M003.yaml
+++ b/metadata/M003.yaml
@@ -14,4 +14,3 @@ Kommentarer: |-
   Er en videreføring av kombinasjonen saksår og sakssekvensnummer (oftest bare kalt "saksnummer") i Noark 4, som fortsatt er obligatorisk identifikasjon på saksmappe. I slike tilfeller skal verdien i mappeID også kopieres til de to metadataelementene *M011 saksaar* og *M012 sakssekvensnummer* i saksmappen.
 Navn: mappeID
 Nr: M003
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M004.yaml
+++ b/metadata/M004.yaml
@@ -14,4 +14,3 @@ Kommentarer: |-
   Er en videreføring av saksår og sakssekvensnummer (oftest bare kalt "saksnummer") i kombinasjon med "dokumentnummer" i Noark 4 (f.eks. 2011/3869-8, dvs. dokument nummer 8 i saksnummer 2011/3869), men trenger ikke ha denne formen for andre deler av arkivet.
 Navn: registreringsID
 Nr: M004
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M005.yaml
+++ b/metadata/M005.yaml
@@ -13,4 +13,3 @@ Kommentarer: Versjonsnummer gjelder bare arkiverte versjoner. Annen versjons­h�
   ligger i komplett Noark, og genererer ikke metadata skal følge med i et arkivuttrekk.
 Navn: versjonsnummer
 Nr: M005
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M006.yaml
+++ b/metadata/M006.yaml
@@ -11,4 +11,3 @@ Kommentarer: Kan være organisasjonsnummer (Brønnøysundregistrene) eller annen
   avtalt med arkivdepotet
 Navn: arkivskaperID
 Nr: M006
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M007.yaml
+++ b/metadata/M007.yaml
@@ -11,4 +11,3 @@ Kommentarer: Dokumentnummeret avgjør i hvilken rekkefølge dokumentene vises i 
   Normalt skal hoveddokument vises før vedleggene.
 Navn: dokumentnummer
 Nr: M007
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M008.yaml
+++ b/metadata/M008.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk av systemet, eventuelt også manuelt
 Kommentarer:
 Navn: moetenummer
 Nr: M008
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M010.yaml
+++ b/metadata/M010.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt når part opprettes
 Kommentarer: Kan være fødselsnummer eller annen personidentifikasjon
 Navn: partID
 Nr: M010
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M011.yaml
+++ b/metadata/M011.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når saksmappen opprettes
 Kommentarer: Se kommentar under *M012 sakssekvensnummer*
 Navn: saksaar
 Nr: M011
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M012.yaml
+++ b/metadata/M012.yaml
@@ -12,4 +12,3 @@ Kommentarer: Kombinasjonen saksår og sakssekvensnummer er ikke obligatorisk, me
   brukt i sakarkiver.
 Navn: sakssekvensnummer
 Nr: M012
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M013.yaml
+++ b/metadata/M013.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når journalposten opprettes
 Kommentarer: Kombineres med *M014 journalsekvensnummer*, se kommentar under denne
 Navn: journalaar
 Nr: M013
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M014.yaml
+++ b/metadata/M014.yaml
@@ -13,4 +13,3 @@ Kommentarer: |-
   Kombinasjonen journalår og sekvensnummer er ikke obligatorisk, men anbefales brukt i sakarkiver. Noen rapporter er sortert på denne kombinasjonen, f.eks. løpende- og offentlig journal. Dersom journalår og sekvensnummer ikke brukes, må kronologiske utskrifter sorteres etter andre kriterier (f.eks. journalpostens *opprettetDato*). I Noark 4 skulle sekvensnummeret vises før journalåret (f.eks. 25367/2011) for at det ikke skulle blandes sammen med saksnummeret som har året først.
 Navn: journalsekvensnummer
 Nr: M014
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M015.yaml
+++ b/metadata/M015.yaml
@@ -15,4 +15,3 @@ Kommentarer: Er ikke obligatorisk, men anbefales brukt i sakarkiver. Kombineres 
   saksmappen.
 Navn: journalpostnummer
 Nr: M015
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M020.yaml
+++ b/metadata/M020.yaml
@@ -15,4 +15,3 @@ Kommentarer: For saksmappe og journalpost vil dette tilsvare "Sakstittel" og "Do
   Disse navnene kan beholdes i grensesnittet.
 Navn: tittel
 Nr: M020
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M021.yaml
+++ b/metadata/M021.yaml
@@ -12,4 +12,3 @@ Kommentarer: Tilsvarende attributt finnes ikke i Noark 4 (men noen tabeller hadd
   egne attributter for merknad som kunne brukes som et beskrivelsesfelt)
 Navn: beskrivelse
 Nr: M021
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M022.yaml
+++ b/metadata/M022.yaml
@@ -12,4 +12,3 @@ Kommentarer: Nøkkelord kan brukes for å forbedre mulighetene for søking og gj
   Nøkkelord skal ikke erstatte klassifikasjon.
 Navn: noekkelord
 Nr: M022
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M023.yaml
+++ b/metadata/M023.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt ved opprettelsen av arkivet.
 Kommentarer:
 Navn: arkivskaperNavn
 Nr: M023
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M024.yaml
+++ b/metadata/M024.yaml
@@ -17,4 +17,3 @@ Kommentarer: Sakarkiver har tradisjonelt ikke noen forfatter på journalposten, 
   erstattes med en kilde (f.eks. et system).
 Navn: forfatter
 Nr: M024
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M025.yaml
+++ b/metadata/M025.yaml
@@ -13,4 +13,3 @@ Kommentarer: I løpende og offentlig journaler skal også offentligTittel være 
   ord i tittelfeltet skal skjermes.
 Navn: offentligTittel
 Nr: M025
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M050.yaml
+++ b/metadata/M050.yaml
@@ -16,4 +16,3 @@ Kilde: Registreres manuelt når arkivet opprettes eller ved skifte av status.
 Kommentarer:
 Navn: arkivstatus
 Nr: M050
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M051.yaml
+++ b/metadata/M051.yaml
@@ -18,4 +18,3 @@ Kilde: Registreres manuelt når arkivdelen opprettes eller ved skifte av status.
 Kommentarer: Arkivdeler som avleveres skal ha status "Avsluttet periode"
 Navn: arkivdelstatus
 Nr: M051
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M052.yaml
+++ b/metadata/M052.yaml
@@ -18,4 +18,3 @@ Kilde: Registreres automatisk gjennom forskjellig saksbehandlings­funksjonalite
 Kommentarer: Saksmapper som avleveres skal ha status "Avsluttet" eller "Utgår".
 Navn: saksstatus
 Nr: M052
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M053.yaml
+++ b/metadata/M053.yaml
@@ -20,4 +20,3 @@ Kilde: Registreres automatisk gjennom forskjellig saksbehandlings­funksjonalite
 Kommentarer: Journalposter som avleveres skal ha status "Arkivert" eller "Utgår".
 Navn: journalstatus
 Nr: M053
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M054.yaml
+++ b/metadata/M054.yaml
@@ -14,4 +14,3 @@ Kilde: Kan endres automatisk ved endring i saksstatus eller journalstatus.
 Kommentarer: Dokumentbeskrivelser som avlevers skal ha status "Dokumentet er ferdigstilt".
 Navn: dokumentstatus
 Nr: M054
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M055.yaml
+++ b/metadata/M055.yaml
@@ -15,4 +15,3 @@ Kilde:
 Kommentarer:
 Navn: moeteregistreringsstatus
 Nr: M055
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M056.yaml
+++ b/metadata/M056.yaml
@@ -14,4 +14,3 @@ Kilde: Registreres manuelt ved foreldelse
 Kommentarer:
 Navn: presedensstatus
 Nr: M056
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M082.yaml
+++ b/metadata/M082.yaml
@@ -17,4 +17,3 @@ Kilde: Registreres automatisk av systemet eller manuelt
 Kommentarer: Tilsvarer "Noark dokumenttype" i Noark 4
 Navn: journalposttype
 Nr: M082
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M083.yaml
+++ b/metadata/M083.yaml
@@ -16,4 +16,3 @@ Kilde: Registreres automatisk av systemet eller manuelt
 Kommentarer:
 Navn: dokumenttype
 Nr: M083
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M084.yaml
+++ b/metadata/M084.yaml
@@ -15,4 +15,3 @@ Kilde:
 Kommentarer:
 Navn: merknadstype
 Nr: M084
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M085.yaml
+++ b/metadata/M085.yaml
@@ -16,4 +16,3 @@ Kilde:
 Kommentarer:
 Navn: moeteregistreringstype
 Nr: M085
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M086.yaml
+++ b/metadata/M086.yaml
@@ -20,4 +20,3 @@ Kilde: Registreres manuelt ved opprettelse av *klassifikasjonssystem*
 Kommentarer:
 Navn: klassifikasjonstype
 Nr: M086
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M087.yaml
+++ b/metadata/M087.yaml
@@ -20,4 +20,3 @@ Kommentarer: Korrespondansetype forekommer én gang innenfor objektet korrespond
   men denne kan forekomme flere ganger innenfor en journalpost.
 Navn: korrespondanseparttype
 Nr: M087
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M088.yaml
+++ b/metadata/M088.yaml
@@ -16,4 +16,3 @@ Kilde:
 Kommentarer:
 Navn: moetesakstype
 Nr: M088
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M089.yaml
+++ b/metadata/M089.yaml
@@ -16,4 +16,3 @@ Kommentarer: Siste versjon av et dokument skal vanligvis ikke kunne slettes. Sle
   av innholdet i en arkivdel skal bare kunne utføres av autorisert personale.
 Navn: slettingstype
 Nr: M089
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M100.yaml
+++ b/metadata/M100.yaml
@@ -10,4 +10,3 @@ Kilde: Settes automatisk til samme dato som *M600 opprettetDato*
 Kommentarer:
 Navn: saksdato
 Nr: M100
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M101.yaml
+++ b/metadata/M101.yaml
@@ -10,4 +10,3 @@ Kilde: Settes automatisk når journalstatus settes til journalført.
 Kommentarer:
 Navn: journaldato
 Nr: M101
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M102.yaml
+++ b/metadata/M102.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt ved opprettelsen av en møtemappe.
 Kommentarer:
 Navn: moetedato
 Nr: M102
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M103.yaml
+++ b/metadata/M103.yaml
@@ -10,4 +10,3 @@ Kilde: Datoen hentes automatisk fra dokumentet, eller registreres manuelt
 Kommentarer: Kan brukes både for inngående, utgående og organinterne dokumenter
 Navn: dokumentetsDato
 Nr: M103
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M104.yaml
+++ b/metadata/M104.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres manuelt eller automatisk av systemet ved elektronisk kommunik
 Kommentarer: Merk at mottattDato ikke behøver å være identisk med *M600 opprettetDato*
 Navn: mottattDato
 Nr: M104
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M105.yaml
+++ b/metadata/M105.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres manuelt eller automatisk av systemet ved elektronisk kommunik
 Kommentarer:
 Navn: sendtDato
 Nr: M105
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M106.yaml
+++ b/metadata/M106.yaml
@@ -13,4 +13,3 @@ Kommentarer: Det er ikke spesifisert noen dato for tilbakelevering. Tilbakelever
   logging av utlån av fysiske dokumenter.
 Navn: utlaantDato
 Nr: M106
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M107.yaml
+++ b/metadata/M107.yaml
@@ -11,4 +11,3 @@ Kommentarer: Det kan tenkes tilfeller hvor startdatoen ikke er identisk med dato
   arkivdelen ble opprettet
 Navn: arkivperiodeStartDato
 Nr: M107
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M108.yaml
+++ b/metadata/M108.yaml
@@ -11,4 +11,3 @@ Kommentarer: Det kan forekomme tilfeller hvor sluttdatoen ikke er identisk med d
   arkivdelen ble avsluttet.
 Navn: arkivperiodeSluttDato
 Nr: M108
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M109.yaml
+++ b/metadata/M109.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt
 Kommentarer: Forfallsdato kan være angitt som en betingelse i det inngående dokumentet
 Navn: forfallsdato
 Nr: M109
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M110.yaml
+++ b/metadata/M110.yaml
@@ -12,4 +12,3 @@ Kommentarer: Dato for offentlighetsvurdering kan brukes dersom inngående dokume
   på et litt senere tidspunkt.
 Navn: offentlighetsvurdertDato
 Nr: M110
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M111.yaml
+++ b/metadata/M111.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres manuelt ved opprettelse av presedens, men bør også kunne he
 Kommentarer:
 Navn: presedensDato
 Nr: M111
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M112.yaml
+++ b/metadata/M112.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres når avleveringspakken produseres
 Kommentarer: Startdatoen vil vanligvis være identisk med *M107 arkivperiodeStartdato*
 Navn: journalStartDato
 Nr: M112
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M113.yaml
+++ b/metadata/M113.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres når avleveringspakken produseres
 Kommentarer: Sluttdatoen vil vanligvis være identisk med *M108 arkivperiodeSluttdato*
 Navn: journalSluttDato
 Nr: M113
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M202.yaml
+++ b/metadata/M202.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk når arkivdelen som er arvtaker opprettes
 Kommentarer:
 Navn: referanseForloeper
 Nr: M202
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M203.yaml
+++ b/metadata/M203.yaml
@@ -12,4 +12,3 @@ Kilde: Registreres automatisk når det opprettes en arkivdel som defineres som a
 Kommentarer:
 Navn: referanseArvtaker
 Nr: M203
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M208.yaml
+++ b/metadata/M208.yaml
@@ -23,4 +23,3 @@ Kommentarer: 'Alle mapper skal ha referanse til arkivdel (selv om tilhørigheten
   opprettes.'
 Navn: referanseArkivdel
 Nr: M208
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M209.yaml
+++ b/metadata/M209.yaml
@@ -12,4 +12,3 @@ Kommentarer: Kan også brukes for å bygge opp mangefasettert klassifikasjon og 
   klassifikasjonssystem "K-kodene".
 Navn: referanseSekundaerKlassifikasjon
 Nr: M209
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M210.yaml
+++ b/metadata/M210.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når kryssreferanse opprettes
 Kommentarer:
 Navn: referanseTilMappe
 Nr: M210
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M212.yaml
+++ b/metadata/M212.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk når en kryssreferanse opprettes
 Kommentarer:
 Navn: referanseTilRegistrering
 Nr: M212
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M215.yaml
+++ b/metadata/M215.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt eller automatisk ved avskrivning
 Kommentarer:
 Navn: referanseAvskrivesAvJournalpost
 Nr: M215
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M217.yaml
+++ b/metadata/M217.yaml
@@ -14,4 +14,3 @@ Kilde: Registreres automatisk eller manuelt når et dokument blir tilknyttet en 
 Kommentarer:
 Navn: tilknyttetRegistreringSom
 Nr: M217
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M218.yaml
+++ b/metadata/M218.yaml
@@ -15,4 +15,3 @@ Kommentarer: Referansen skal være en "sti" (dvs. også inneholde katalogstruktu
   skal angis relativt i forhold til filen *arkivstruktur.xml*.
 Navn: referanseDokumentfil
 Nr: M218
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M219.yaml
+++ b/metadata/M219.yaml
@@ -12,4 +12,3 @@ Kommentarer: Kryssreferansen kan gå til en eller flere klasser innenfor samme k
   sammen beslektede klasser som ikke kan utledes fra det hierarkiske klassifikasjonssystemet.
 Navn: referanseTilKlasse
 Nr: M219
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M221.yaml
+++ b/metadata/M221.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt
 Kommentarer: Kan brukes dersom et møte går over flere dager
 Navn: referanseForrigeMoete
 Nr: M221
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M222.yaml
+++ b/metadata/M222.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt
 Kommentarer: Kan brukes dersom et møte går over flere dager
 Navn: referanseNesteMoete
 Nr: M222
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M223.yaml
+++ b/metadata/M223.yaml
@@ -11,4 +11,3 @@ Kommentarer: Kan brukes for å knytte sammen dokumenter som tilhører samme "mø
   (Møtemappen har ikke noe eget nivå for møtesaker.)
 Navn: referanseTilMoeteregistrering
 Nr: M223
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M224.yaml
+++ b/metadata/M224.yaml
@@ -10,4 +10,3 @@ Kilde:
 Kommentarer: Kan brukes for å knytte sammen dokumenter som tilhører samme "møtesak"
 Navn: referanseFraMoeteregistrering
 Nr: M224
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M300.yaml
+++ b/metadata/M300.yaml
@@ -21,4 +21,3 @@ Kommentarer: Obligatorisk ved blanding av fysisk og elektronisk arkiv. Er hele a
   til *M208 referanseArkivdel.*
 Navn: dokumentmedium
 Nr: M300
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M301.yaml
+++ b/metadata/M301.yaml
@@ -17,4 +17,3 @@ Kommentarer: Fysiske dokumenters plassering skal ellers gå fram av arkivstruktu
   ("dokumentnummer"). Vedlegg skal legges sammen med tilhørende hoveddokument.
 Navn: oppbevaringssted
 Nr: M301
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M302.yaml
+++ b/metadata/M302.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt eller automatisk fra fagsystem
 Kommentarer:
 Navn: partNavn
 Nr: M302
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M303.yaml
+++ b/metadata/M303.yaml
@@ -16,4 +16,3 @@ Kilde: Registreres manuelt eller automatisk fra fagsystem
 Kommentarer:
 Navn: partRolle
 Nr: M303
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M304.yaml
+++ b/metadata/M304.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt
 Kommentarer:
 Navn: antallVedlegg
 Nr: M304
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M305.yaml
+++ b/metadata/M305.yaml
@@ -14,4 +14,3 @@ Kommentarer: Merk at på journalpostnivå grupperes *administrativEnhet* sammen 
   som skal følges opp.
 Navn: administrativEnhet
 Nr: M305
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M306.yaml
+++ b/metadata/M306.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk på grunnlag av innlogget bruker eller annen saksb
 Kommentarer:
 Navn: saksansvarlig
 Nr: M306
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M307.yaml
+++ b/metadata/M307.yaml
@@ -13,4 +13,3 @@ Kommentarer: Merk at *saksbehandler* grupperes inn i korrespondansepart på jour
   Se kommentar til *M305 administrativEnhet*.
 Navn: saksbehandler
 Nr: M307
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M308.yaml
+++ b/metadata/M308.yaml
@@ -14,4 +14,3 @@ Kilde: Registreres automatisk på grunnlag av innlogget bruker, kan overstyres m
 Kommentarer:
 Navn: journalenhet
 Nr: M308
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M309.yaml
+++ b/metadata/M309.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres manuelt ved utlån
 Kommentarer:
 Navn: utlaantTil
 Nr: M309
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M310.yaml
+++ b/metadata/M310.yaml
@@ -11,4 +11,3 @@ Kommentarer: Merknaden bør gjelde selve saksbehandlingen eller forhold rundt ar
   av dokumentene som tilhører arkivenheten.
 Navn: merknadstekst
 Nr: M310
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M311.yaml
+++ b/metadata/M311.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt ved opprettelse av presedens
 Kommentarer:
 Navn: presedensHjemmel
 Nr: M311
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M312.yaml
+++ b/metadata/M312.yaml
@@ -13,4 +13,3 @@ Kommentarer: En rettskildefaktor kan være en lov- eller forskriftstekst, lovfor
   rettsoppfatninger, reelle hensyn, folkerett, EU-/ EØS-rett mv.
 Navn: rettskildefaktor
 Nr: M312
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M313.yaml
+++ b/metadata/M313.yaml
@@ -13,4 +13,3 @@ Kommentarer: Både løpende og offentlig journal er i utgangspunktet selektert e
   journaldato. Andre kriterier kan eventuelt brukes i tillegg.
 Navn: seleksjon
 Nr: M313
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M370.yaml
+++ b/metadata/M370.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt ved opprettelsen av møtemappen
 Kommentarer:
 Navn: utvalg
 Nr: M370
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M371.yaml
+++ b/metadata/M371.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt ved opprettelsen av møtemappen
 Kommentarer:
 Navn: moetested
 Nr: M371
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M372.yaml
+++ b/metadata/M372.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres manuelt ved opprettelsen av møtemappen, kan eventuelt også 
 Kommentarer:
 Navn: moetedeltakerNavn
 Nr: M372
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M373.yaml
+++ b/metadata/M373.yaml
@@ -14,4 +14,3 @@ Kilde:
 Kommentarer:
 Navn: moetedeltakerFunksjon
 Nr: M373
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M400.yaml
+++ b/metadata/M400.yaml
@@ -12,4 +12,3 @@ Kommentarer: Navn på korrespondansepart forekommer én gang innenfor objektet k
   elementene nedenfor.
 Navn: korrespondansepartNavn
 Nr: M400
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M406.yaml
+++ b/metadata/M406.yaml
@@ -11,4 +11,3 @@ Kommentarer: En postadresse kan angis som flere elementer ("adresselinjer"), noe
   kan være aktuelt ved bestemte utenlandske adresser
 Navn: postadresse
 Nr: M406
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M407.yaml
+++ b/metadata/M407.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:
 Navn: postnummer
 Nr: M407
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M408.yaml
+++ b/metadata/M408.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:
 Navn: poststed
 Nr: M408
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M409.yaml
+++ b/metadata/M409.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:
 Navn: land
 Nr: M409
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M410.yaml
+++ b/metadata/M410.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:
 Navn: epostadresse
 Nr: M410
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M411.yaml
+++ b/metadata/M411.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt eller automatisk
 Kommentarer:
 Navn: telefonnummer
 Nr: M411
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M412.yaml
+++ b/metadata/M412.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres manuelt eller automatisk
 Kommentarer:
 Navn: kontaktperson
 Nr: M412
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M450.yaml
+++ b/metadata/M450.yaml
@@ -16,4 +16,3 @@ Kilde: Registreres manuelt ved opprettelse av *arkivdel* eller *klasse*. Arves t
 Kommentarer:
 Navn: kassasjonsvedtak
 Nr: M450
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M451.yaml
+++ b/metadata/M451.yaml
@@ -12,4 +12,3 @@ Kommentarer: Tidspunktet for når bevaringstiden starter å løpe, vil vanligvis
   når en mappe avsluttes. Men andre regler kan være aktuelle.
 Navn: bevaringstid
 Nr: M451
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M452.yaml
+++ b/metadata/M452.yaml
@@ -12,4 +12,3 @@ Kilde: Datoen beregnes automatisk på grunnlag av *M451 Bevaringstid*, eller reg
 Kommentarer:
 Navn: kassasjonsdato
 Nr: M452
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M453.yaml
+++ b/metadata/M453.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres manuelt ved opprettelse av *arkivdel* eller *klasse*. Arves t
 Kommentarer: Hjemmel kan f.eks. være Riksarkivarens bevarings- og kassasjons­vedtak.
 Navn: kassasjonshjemmel
 Nr: M453
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M500.yaml
+++ b/metadata/M500.yaml
@@ -19,4 +19,3 @@ Kilde: Registreres manuelt ved valg fra liste, kan også registres automatisk
 Kommentarer:
 Navn: tilgangsrestriksjon
 Nr: M500
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M501.yaml
+++ b/metadata/M501.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk på grunnlag av valgt tilgangskode, kan overstyres
 Kommentarer:
 Navn: skjermingshjemmel
 Nr: M501
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M502.yaml
+++ b/metadata/M502.yaml
@@ -31,4 +31,3 @@ Kommentarer: Skjerming av klasseID (arkivnøkkel, arkivkode) er f.eks. aktuelt n
   skjermingsbehovet er vurdert.
 Navn: skjermingMetadata
 Nr: M502
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M503.yaml
+++ b/metadata/M503.yaml
@@ -16,4 +16,3 @@ Kommentarer: Dersom deler av dokumentet skal skjermes, må dokumentet også finn
   en variant. Her må all informasjon som skal skjermes, være "sladdet".
 Navn: skjermingDokument
 Nr: M503
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M504.yaml
+++ b/metadata/M504.yaml
@@ -11,4 +11,3 @@ Kommentarer: Tidspunktet for når skjermingsvarigheten starter å løpe, vil van
   være når journalposten ble registrert, men det skal være mulig med andre regler.
 Navn: skjermingsvarighet
 Nr: M504
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M505.yaml
+++ b/metadata/M505.yaml
@@ -10,4 +10,3 @@ Kilde: Datoen beregnes automatisk på grunnlag av *M504 skjermingsvarighet*
 Kommentarer:
 Navn: skjermingOpphoererDato
 Nr: M505
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M506.yaml
+++ b/metadata/M506.yaml
@@ -23,4 +23,3 @@ Kommentarer: Dokumenter gradert "Strengt hemmelig", "Hemmelig", "Konfidensielt" 
   innsyn.
 Navn: gradering
 Nr: M506
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M507.yaml
+++ b/metadata/M507.yaml
@@ -17,4 +17,3 @@ Kilde: Registreres automatisk knyttet til funksjonalitet for elektronisk signatu
 Kommentarer:
 Navn: elektroniskSignaturSikkerhetsnivaa
 Nr: M507
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M508.yaml
+++ b/metadata/M508.yaml
@@ -16,4 +16,3 @@ Kommentarer: Dersom signaturen er verifisert, skal det logges hvem som verifiser
   den og når det skjedde
 Navn: elektroniskSignaturVerifisert
 Nr: M508
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M580.yaml
+++ b/metadata/M580.yaml
@@ -11,4 +11,3 @@ Kommentarer: Navn på bruker vil registreres mange steder i arkivstrukturen, f.e
   som saksansvarlig eller saksbehandler, og ved forskjellige typer logging.
 Navn: brukerNavn
 Nr: M580
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M581.yaml
+++ b/metadata/M581.yaml
@@ -16,4 +16,3 @@ Kilde: Registreres manuelt av administrator
 Kommentarer:
 Navn: brukerRolle
 Nr: M581
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M582.yaml
+++ b/metadata/M582.yaml
@@ -14,4 +14,3 @@ Kilde: Registreres manuelt av administrator
 Kommentarer:
 Navn: brukerstatus
 Nr: M582
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M583.yaml
+++ b/metadata/M583.yaml
@@ -11,4 +11,3 @@ Kommentarer: Navn på administrativ enhet vil registreres flere steder i arkivst
   f.eks. sammen med saksansvarlig eller saksbehandler på saksmappe eller journalpost.
 Navn: administrativEnhetNavn
 Nr: M583
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M584.yaml
+++ b/metadata/M584.yaml
@@ -14,4 +14,3 @@ Kilde: Registreres manuelt av administrator
 Kommentarer:
 Navn: administrativEnhetsstatus
 Nr: M584
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M585.yaml
+++ b/metadata/M585.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt av administrator
 Kommentarer:
 Navn: referanseOverordnetEnhet
 Nr: M585
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M600.yaml
+++ b/metadata/M600.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: opprettetDato
 Nr: M600
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M601.yaml
+++ b/metadata/M601.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: opprettetAv
 Nr: M601
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M602.yaml
+++ b/metadata/M602.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk av systemet når enheten avsluttes
 Kommentarer:
 Navn: avsluttetDato
 Nr: M602
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M603.yaml
+++ b/metadata/M603.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: avsluttetAv
 Nr: M603
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M604.yaml
+++ b/metadata/M604.yaml
@@ -13,4 +13,3 @@ Kommentarer: Arkivering innebærer at dokumentene blir "frosset", dvs. sperret f
   all videre redigering/endring
 Navn: arkivertDato
 Nr: M604
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M605.yaml
+++ b/metadata/M605.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk ved utførelse av en funksjon som markerer at doku
 Kommentarer:
 Navn: arkivertAv
 Nr: M605
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M609.yaml
+++ b/metadata/M609.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk ved produksjon av avleveringsuttrekk
 Kommentarer:
 Navn: antallJournalposter
 Nr: M609
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M611.yaml
+++ b/metadata/M611.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk av systemet
 Kommentarer:
 Navn: merknadsdato
 Nr: M611
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M612.yaml
+++ b/metadata/M612.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk av systemet
 Kommentarer:
 Navn: merknadRegistrertAv
 Nr: M612
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M613.yaml
+++ b/metadata/M613.yaml
@@ -12,4 +12,3 @@ Kommentarer: Informasjon om sletting av dokumenter i produksjonsformat skal ikke
   Sletting må ikke blandes sammen med kassasjon.
 Navn: slettetDato
 Nr: M613
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M614.yaml
+++ b/metadata/M614.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk når et dokument blir slettet
 Kommentarer: Sletting må ikke blandes sammen med kassasjon.
 Navn: slettetAv
 Nr: M614
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M615.yaml
+++ b/metadata/M615.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk ved konvertering
 Kommentarer:
 Navn: konvertertDato
 Nr: M615
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M616.yaml
+++ b/metadata/M616.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved konvertering
 Kommentarer:
 Navn: konvertertAv
 Nr: M616
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M617.yaml
+++ b/metadata/M617.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk nå avskrivning foretas
 Kommentarer:
 Navn: avskrivningsdato
 Nr: M617
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M618.yaml
+++ b/metadata/M618.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når avskrivning foretas
 Kommentarer:
 Navn: avskrevetAv
 Nr: M618
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M619.yaml
+++ b/metadata/M619.yaml
@@ -17,4 +17,3 @@ Kilde: Registreres automatisk når konvertering utføres.
 Kommentarer:
 Navn: avskrivningsmaate
 Nr: M619
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M620.yaml
+++ b/metadata/M620.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk nå tilknytning foretas
 Kommentarer:
 Navn: tilknyttetDato
 Nr: M620
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M621.yaml
+++ b/metadata/M621.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når tilknytning foretas
 Kommentarer:
 Navn: tilknyttetAv
 Nr: M621
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M622.yaml
+++ b/metadata/M622.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når verifisering utføres
 Kommentarer:
 Navn: verifisertDato
 Nr: M622
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M623.yaml
+++ b/metadata/M623.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når verifisering utføres
 Kommentarer:
 Navn: verifisertAv
 Nr: M623
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M624.yaml
+++ b/metadata/M624.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved gradering
 Kommentarer:
 Navn: graderingsdato
 Nr: M624
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M625.yaml
+++ b/metadata/M625.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved gradering
 Kommentarer:
 Navn: gradertAv
 Nr: M625
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M626.yaml
+++ b/metadata/M626.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved nedgradering
 Kommentarer:
 Navn: nedgraderingsdato
 Nr: M626
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M627.yaml
+++ b/metadata/M627.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved nedgradering
 Kommentarer:
 Navn: nedgradertAv
 Nr: M627
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M628.yaml
+++ b/metadata/M628.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk dersom det finnes funksjonalitet for å godkjenne 
 Kommentarer:
 Navn: presedensGodkjentDato
 Nr: M628
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M629.yaml
+++ b/metadata/M629.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk dersom det finnes funksjonalitet for å godkjenne 
 Kommentarer:
 Navn: presedensGodkjentAv
 Nr: M629
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M630.yaml
+++ b/metadata/M630.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når kassasjon utføres
 Kommentarer:
 Navn: kassertDato
 Nr: M630
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M631.yaml
+++ b/metadata/M631.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når kassasjon utføres
 Kommentarer:
 Navn: kassertAv
 Nr: M631
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M660.yaml
+++ b/metadata/M660.yaml
@@ -12,4 +12,3 @@ Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytTil
 Nr: M660
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M661.yaml
+++ b/metadata/M661.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytMottattDato
 Nr: M661
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M662.yaml
+++ b/metadata/M662.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytSendtDato
 Nr: M662
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M663.yaml
+++ b/metadata/M663.yaml
@@ -15,4 +15,3 @@ Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytStatus
 Nr: M663
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M664.yaml
+++ b/metadata/M664.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres manuelt
 Kommentarer:
 Navn: flytMerknad
 Nr: M664
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M665.yaml
+++ b/metadata/M665.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytFra
 Nr: M665
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M680.yaml
+++ b/metadata/M680.yaml
@@ -11,4 +11,3 @@ Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: referanseArkivenhet
 Nr: M680
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M681.yaml
+++ b/metadata/M681.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: referanseMetadata
 Nr: M681
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M682.yaml
+++ b/metadata/M682.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: endretDato
 Nr: M682
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M683.yaml
+++ b/metadata/M683.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: endretAv
 Nr: M683
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M684.yaml
+++ b/metadata/M684.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: tidligereVerdi
 Nr: M684
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M685.yaml
+++ b/metadata/M685.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: nyVerdi
 Nr: M685
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M700.yaml
+++ b/metadata/M700.yaml
@@ -17,4 +17,3 @@ Kilde: Registreres automatisk når dokumentet arkiveres
 Kommentarer:
 Navn: variantformat
 Nr: M700
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M701.yaml
+++ b/metadata/M701.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk når dokumentet arkiveres
 Kommentarer: Faste verdier bestemmes senere
 Navn: format
 Nr: M701
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M702.yaml
+++ b/metadata/M702.yaml
@@ -10,4 +10,3 @@ Kilde:
 Kommentarer:
 Navn: formatDetaljer
 Nr: M702
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M705.yaml
+++ b/metadata/M705.yaml
@@ -11,4 +11,3 @@ Kilde: Påføres automatisk i forbindelse med eksport for avlevering
 Kommentarer:
 Navn: sjekksum
 Nr: M705
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M706.yaml
+++ b/metadata/M706.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk i forbindelse med eksport for avlevering
 Kommentarer:
 Navn: sjekksumAlgoritme
 Nr: M706
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M707.yaml
+++ b/metadata/M707.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk i forbindelse med eksport for avlevering
 Kommentarer:
 Navn: filstoerrelse
 Nr: M707
-Obligatorisk/valgfri: Obligatorisk

--- a/metadata/M711.yaml
+++ b/metadata/M711.yaml
@@ -11,4 +11,3 @@ Kilde:
 Kommentarer:
 Navn: virksomhetsspesifikkeMetadata
 Nr: M711
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M712.yaml
+++ b/metadata/M712.yaml
@@ -11,4 +11,3 @@ Kommentarer: Dette vil vanligvis være produksjonsformatet, men kan også være 
   arkivformat. Faste verdier bestemmes senere.
 Navn: konvertertFraFormat
 Nr: M712
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M713.yaml
+++ b/metadata/M713.yaml
@@ -10,4 +10,3 @@ Kilde: Registreres automatisk ved konvertering
 Kommentarer: Faste verdier bestemmes senere
 Navn: konvertertTilFormat
 Nr: M713
-Obligatorisk/valgfri: Betinget obligatorisk

--- a/metadata/M714.yaml
+++ b/metadata/M714.yaml
@@ -10,4 +10,3 @@ Kilde:
 Kommentarer:
 Navn: konverteringsverktoey
 Nr: M714
-Obligatorisk/valgfri: Valgfri

--- a/metadata/M715.yaml
+++ b/metadata/M715.yaml
@@ -10,4 +10,3 @@ Kilde:
 Kommentarer:
 Navn: konverteringskommentar
 Nr: M715
-Obligatorisk/valgfri: Valgfri

--- a/scripts/metadata-xml2yaml
+++ b/scripts/metadata-xml2yaml
@@ -31,8 +31,6 @@ class Converter(object):
             }
             for line in sub.iterchildren():
                 field = line.tag
-                if 'Obligatorisk' == field:
-                    field = 'Obligatorisk/valgfri'
                 value = line.text
                 if 'Forekomster' == field and 'En' == value:
                     value = 1

--- a/scripts/metadata2rst
+++ b/scripts/metadata2rst
@@ -8,7 +8,7 @@ import yaml
 
 def main():
     retval = 0
-    required = ('Nr', 'Navn', 'Datatype', 'Avleveres', 'Obligatorisk/valgfri',
+    required = ('Nr', 'Navn', 'Datatype', 'Avleveres',
                 'Forekomster', 'Definisjon', 'Arkivenhet', 'Kilde')
     optional = ('Noark 4', 'Arv', 'Betingelser', 'Kommentarer',)
     parser = argparse.ArgumentParser()
@@ -65,7 +65,6 @@ def main():
     else:
         fields = ('Nr',
                   'Navn',
-                  'Obligatorisk/valgfri',
                   'Forekomster',
                   'Definisjon',
                   'Arkivenhet',

--- a/scripts/metadata2xsd
+++ b/scripts/metadata2xsd
@@ -55,7 +55,7 @@ class XMLFile(object):
 
 def main():
     retval = 0
-    required = ('Nr', 'Navn', 'Datatype', 'Avleveres', 'Obligatorisk/valgfri',
+    required = ('Nr', 'Navn', 'Datatype', 'Avleveres',
                 'Forekomster', 'Definisjon', 'Arkivenhet', 'Kilde')
     optional = ('Noark 4', 'Arv', 'Betingelser', 'Kommentarer',)
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
…gene.

Det vil variere fra entitet til entitet om en attributt er obligatorisk
eller valgfri, så det er misvisende å ha feltet med i metadatakatalogen.
Det holder at det vises i forekostkolonnen i tillegg B, dvs. metadata
gruppert på objekt.

Endringsforslaget inneholder ikke endringene i den avledede filen
kapitler/110-vedlegg_1_metadatakatalog-auto.rst for å unngå git-konflikter.

Relatert til #24.