### PR TITLE
Legg til systemID på part og korrespondansepart.

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -827,6 +827,12 @@ Metadata for *korrespondansepart*
    - **Forek.**
    - **Avl.**
    - **Datatype**
+ * - M001
+   - systemID
+   -
+   - 1
+   - A
+   - Tekststreng
  * - M087
    - korrespondanseparttype
    - (AM.IHTYPE, AM.KOPIMOT, AM.GRUPPE MOT)
@@ -1604,6 +1610,12 @@ Metadata for *part*
    - **Forek.**
    - **Avl.**
    - **Datatype**
+ * - M001
+   - systemID
+   -
+   - 1
+   - A
+   - Tekststreng
  * - M010
    - partID
    - 

--- a/metadata/M010.yaml
+++ b/metadata/M010.yaml
@@ -7,7 +7,8 @@ Definisjon: Unik ID for en part
 Forekomster: 0-1
 Gruppe: Identifikasjon
 Kilde: Registreres manuelt når part opprettes
-Kommentarer: Kan være fødselsnummer eller annen personidentifikasjon
+Kommentarer: Kan være fødselsnummer eller annen eksternt
+  definert personidentifikasjon.
 Navn: partID
 Nr: M010
 Obligatorisk/valgfri: Valgfri


### PR DESCRIPTION
Dette gjør det mulig å referere til spesifikke part/korrespondasepart-
oppføringer i andre deler.  Dette er nyttig i avskrivningsinformasjon.
Det er også nyttig i tjenestegrensesnittet som trenger å kunne henvise
til og oppdatere individuelle *part-oppføringer.

Fixes #65