### PR TITLE
Opprett M716 mimeType i metadatakatalogen.

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -1443,6 +1443,12 @@ Metadata for *dokumentobjekt*
    - 1
    - A
    - Tekststreng
+ * - M716
+   - mimeType
+   -
+   - 0-1
+   - A
+   - Tekststreng
 
 Metadata for *konvertering*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/metadata/M716.yaml
+++ b/metadata/M716.yaml
@@ -1,0 +1,18 @@
+Arkivenhet: dokumentobjekt
+Arv: Nei
+Avleveres: A
+Betingelser: Kan ikke endres
+Datatype: Tekststreng
+Definisjon: Dokumentets MIME-type
+Forekomster: 0-1
+Gruppe: Tekniske metadata
+Kilde: Registreres automatisk når et dokument overføres til arkivet
+  eller settes av arkivklient.
+Kommentarer: MIME-type for bruk når fil overføres via for eksempel
+ HTTP og SMTP.  MIME-typer er definert i IETF RFC 2046 og en katalog
+ over offisielle verdier vedlikeholdes av Internet Assigned Numbers
+ Authority (IANA).  Merk at en PRONOM-kode kan ha flere kjente
+ MIME-typer og en MIME-type kan være koblet til flere PRONOM-koder.
+Navn: mimeType
+Nr: M716
+Obligatorisk/valgfri: Valgfri


### PR DESCRIPTION
Henviser til IETF, IANA og PRONOM som kilde til gyldige MIME-typer.

Fixes #35