### PR TITLE
Samkjør datatype for M215/referanseAvskrivesAvJournalpost

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -2337,7 +2337,7 @@ Metadata for *journalpost*
    - AM.AVSAV
    - 0-1
    - A
-   - Tekststreng
+   - registrering.systemID
  * - M500
    - tilgangsrestriksjon
    - JP.TGKODE
@@ -2619,7 +2619,7 @@ Metadata for *journalpost*
    - AM.AVSAV
    - 0-1
    - A
-   - Tekststreng
+   - registrering.systemID
  * - M500
    - tilgangsrestriksjon
    - JP.TGKODE


### PR DESCRIPTION
En av tre oppføringer i tillegg B hadde datatype registrering.systemID,
de to øvrige hadde Tekststreng.  Gjør alle om til registrering.systemID,
slik at det er entydig hvordan en refererer til en journalpost og slik at
tillegg B tilsvarer XSD som har datatype 'ID' for M215.

Relatert til #24.