### PR TITLE
Fjern rest '(unntatt registrering)' fra krav 2.8.3 om nøkkelord.

### DIFF
--- a/kapitler/030-noark-5-datamodell.rst
+++ b/kapitler/030-noark-5-datamodell.rst
@@ -835,8 +835,7 @@ Nøkkelord er valgfritt, og kan forekomme en eller flere ganger i klasse, mappe 
    - Merknad
  * - 2.8.3
    - Det bør finnes en tjeneste/funksjon for å knytte ett eller flere
-     nøkkelord til klasser, mapper og registreringer (unntatt
-     registrering).
+     nøkkelord til klasser, mapper og registreringer.
    - V
    - 
 


### PR DESCRIPTION
Formuleringen ble gjenglemt da basisregistrering og registrering
ble slått sammen.

Fixes #33.