### PR TITLE
La til virksomhetsspesifikkeMetadata for korrespondansepart og dokumentbeskrivelse

### DIFF
--- a/kapitler/070-funksjoner_for_periodiske_oppgaver.rst
+++ b/kapitler/070-funksjoner_for_periodiske_oppgaver.rst
@@ -1090,8 +1090,8 @@ I en avleveringspakke skal journalen normalt dekke en *arkivperiode*, dvs. den p
 Virksomhetsspesifikke metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Dersom Noark 5-løsningen inneholder metadataelementer som ikke er spesifisert i Noark 5, er det likevel mulig å ta disse med i arkivuttrekket. Slike virksomhetsspesifikke metadata blir en del av arkivstrukturen og tas derfor med i **arkivstruktur.xml**. De virksomhetsspesifikke metadataene kan knyttes til arkivenhetene
-klassifikasjonssystem, klasse, arkiv, arkivdel, mappe, registrering, dokumentobjekt eller sakspart gjennom det overordnede elementet *virksomhetsspesifikkeMetadata* som er av XML Schema-datatypen *anyType*.
+Dersom Noark 5-løsningen inneholder metadataelementer som ikke er spesifisert i Noark 5, er det likevel mulig å ta disse med i arkivuttrekket. Slike virksomhetsspesifikke metadata blir en del av arkivstrukturen og tas derfor med i **arkivstruktur.xml**.  De virksomhetsspesifikke metadataene kan knyttes til arkivenhetene
+klassifikasjonssystem, klasse, arkiv, arkivdel, mappe, registrering, dokumentbeskrivelse, dokumentobjekt, part eller korrespondansepart gjennom det overordnede elementet *virksomhetsspesifikkeMetadata* som er av XML Schema-datatypen *anyType*.
 
 Alle virksomhetsspesifikke metadataelementer må være definert i ett eller flere XML-skjemaer, og referanse til aktuelle skjemaer må finnes i arkivstruktur.xml. I tillegg må de virksomhetsspesifikke metadataelementene være tilordnet et *namespace* gjennom tilhørende XML-skjema.
 
@@ -1111,8 +1111,10 @@ Innholdet og betydningen av hvert virksomhetsspesifikt metadataelement skal doku
    - Merknad
  * - 6.4.31
    - Hvis virksomhetsspesifikke metadata skal inngå som en del av
-     arkivuttrekket, skal de knyttes til mappe, registrering eller
-     sakspart i arkivstruktur.xml gjennom elementet
+     arkivuttrekket, skal de knyttes til klassifikasjonssystem,
+     klasse, arkiv, arkivdel, mappe, registrering,
+     dokumentbeskrivelse, dokumentobjekt, part eller
+     korrespondansepart i arkivstruktur.xml gjennom elementet
      *virksomhetsspesifikkeMetadata*.
    - B
    - Obligatorisk ved bruk av virksomhets-spesifikke metadata.

--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -3,7 +3,7 @@ Metadata gruppert på objekter
 
 I denne oversikten blir metadata i Noark 5 gruppert på objekter. Tabellene nedenfor er utgangspunktet for XML-skjemaene som spesifiserer avleveringsformatet. De fleste objektene nedenfor inngår i arkivstrukturen, og skal nøstes inn i én samlet, hierarkisk struktur.
 
-Hver arkivenhet i arkivstrukturen skal ha en *systemID*. Det betyr altså at arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse og dokumentobjekt har en systemID. Andre objekter, som sakspart og korrespondansepart, skal grupperes inn i den arkivenheten de tilhører, og systemID er derfor ikke nødvendig når denne informasjonen avleveres.
+Hver arkivenhet i arkivstrukturen skal ha en *systemID*. Det betyr altså at arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse og dokumentobjekt har en systemID. Andre objekter, som part og korrespondansepart, skal grupperes inn i den arkivenheten de tilhører, og systemID er derfor ikke nødvendig når denne informasjonen avleveres.
 
 Mange av metadataelementene i Noark 5 vil være identiske med attributter i Noark 4. Referanse fra metadataelement til attributt er derfor tatt med i tabellene nedenfor, og kan gi nyttig informasjon om bakoverkompatibilitet. Dersom attributtet angis i parentes, betyr det at det ikke er direkte samsvar mellom metadata og attributt. Attributtene i Noark 4 kan f.eks. være identifikatorer (nøkkelfelter) som brukes for oppslag i hjelpetabeller. I Noark 5 skal ingen slike nøkkelfelter eller kodeverdier avleveres. Alle koder skal være erstattet med mest mulig selvforklarende tekst. Journalposttype (Noark dokumenttype i Noark 4) skal f.eks. avleveres som *"Inngående dokument"* og *"Utgående dokument"*, og ikke med kodene I og U.
 
@@ -1367,12 +1367,12 @@ Merk: En *dokumentbeskrivelse* kan være knyttet til mer enn én enkelt *registr
    - 1
    - A
    - Tekststreng
- * - M???
-   - eksternReferanse
-   - AM.REF
-   - 0-M
-   - Teststreng
-   - Ekstern referanse på innkommende dokumenter.
+ * - M711
+   - virksomhetsspesifikkeMetadata
+   -
+   - 0-1
+   - A
+   - Vilkårlig struktur
 
 Metadata for *sletting*
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -2614,6 +2614,12 @@ Metadata for *korrespondansepart*
    - 0-1
    - A
    - Tekststreng
+ * - M711
+   - virksomhetsspesifikkeMetadata
+   -
+   - 0-1
+   - A
+   - Vilkårlig struktur
 
 Metadata for offentligJournal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I Noark 5 Tjenestegrensesnitt er det beskrevet at en kan legge inn
virksomhetsspesifikkeMetadata koblet til korrespondansepart og
dokumentbeskrivelse.  Dette må reflekteres i spesifikasjonen for
Noark 5, slik at informasjonen kan avleveres.