### PR TITLE
La referanseSekundaerKlassifikasjon til i mappe og registrering

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -533,6 +533,12 @@ Merk: Bare en av objekttypene *klassifikasjonssystem*, *mappe* eller *registreri
    - 0-M
    - A
    - arkivdel.systemID
+ * - M209
+   - referanseSekundaerKlassifikasjon
+   - (KL.ORDNVER)
+   - 0-M
+   - A
+   - klasse.systemID
  * - M711
    - virksomhetsspesifikkeMetadata
    - 
@@ -609,12 +615,6 @@ Spesialisering av: *mappe*
    - 0-1
    - 
    - Tekststreng
- * - M209
-   - referanseSekundaerKlassifikasjon
-   - (KL.ORDNVER)
-   - 0-M
-   - A
-   - klasse.systemID
 
 Metadata for *moetemappe*
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -805,6 +805,12 @@ Merk: Bare en av objekttypene *klassifikasjonssystem*, *mappe* eller *registreri
    - 0-M
    - 
    - Tekststreng
+ * - M209
+   - referanseSekundaerKlassifikasjon
+   - (KL.ORDNVER)
+   - 0-M
+   - A
+   - klasse.systemID
  * - M711
    - virksomhetsspesifikkeMetadata
    - 

--- a/metadata/M209.yaml
+++ b/metadata/M209.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: saksmappe
+Arkivenhet: mappe, registrering
 Arv: Nei
 Avleveres: A
 Betingelser:


### PR DESCRIPTION
Flyttet fra saksmappe til mappe og lagt til i registrering.  Dette gjør
det mulig å emneklassifisere både registreringer og journalposter i tillegg
til mappe for enklere søk basert på emnebasert klassifikasjonssystem.

Fixes #40