### PR TITLE
La til virksomhetsspesifikkeMetadata for resterende arkivenheter

### DIFF
--- a/kapitler/070-funksjoner_for_periodiske_oppgaver.rst
+++ b/kapitler/070-funksjoner_for_periodiske_oppgaver.rst
@@ -1090,7 +1090,8 @@ I en avleveringspakke skal journalen normalt dekke en *arkivperiode*, dvs. den p
 Virksomhetsspesifikke metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Dersom Noark 5-løsningen inneholder metadataelementer som ikke er spesifisert i Noark 5, er det likevel mulig å ta disse med i arkivuttrekket. Slike virksomhetsspesifikke metadata blir en del av arkivstrukturen og tas derfor med i **arkivstruktur.xml**. De virksomhetsspesifikke metadataene kan knyttes til arkivenhetene mappe, registrering eller sakspart gjennom det overordnede elementet *virksomhetsspesifikkeMetadata* som er av XML Schema-datatypen *anyType*.
+Dersom Noark 5-løsningen inneholder metadataelementer som ikke er spesifisert i Noark 5, er det likevel mulig å ta disse med i arkivuttrekket. Slike virksomhetsspesifikke metadata blir en del av arkivstrukturen og tas derfor med i **arkivstruktur.xml**. De virksomhetsspesifikke metadataene kan knyttes til arkivenhetene
+klassifikasjonssystem, klasse, arkiv, arkivdel, mappe, registrering, dokumentobjekt eller sakspart gjennom det overordnede elementet *virksomhetsspesifikkeMetadata* som er av XML Schema-datatypen *anyType*.
 
 Alle virksomhetsspesifikke metadataelementer må være definert i ett eller flere XML-skjemaer, og referanse til aktuelle skjemaer må finnes i arkivstruktur.xml. I tillegg må de virksomhetsspesifikke metadataelementene være tilordnet et *namespace* gjennom tilhørende XML-skjema.
 

--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -153,6 +153,12 @@ Merk: En og bare en av objekttypene *arkiv* eller *arkivdel* grupperes inn i *ar
    - 1
    - A
    - Tekststreng
+ * - M711
+   - virksomhetsspesifikkeMetadata
+   - 
+   - 0-1
+   - A
+   - Vilkårlig struktur
 
 Metadata for *arkivskaper*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -289,6 +295,12 @@ Merk: En og bare en av objekttypene *arkiv* eller *arkivdel* grupperes inn i *ar
    - 0-1
    - A
    - arkivdel.systemID
+ * - M711
+   - virksomhetsspesifikkeMetadata
+   - 
+   - 0-1
+   - A
+   - Vilkårlig struktur
 
 Metadata for *klassifikasjonssystem*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -355,6 +367,12 @@ Merk: Bare en av objekttypene *klassifikasjonssystem*, *mappe* eller *registreri
    - 0-1
    - A
    - Tekststreng
+ * - M711
+   - virksomhetsspesifikkeMetadata
+   - 
+   - 0-1
+   - A
+   - Vilkårlig struktur
 
 Metadata for *klasse*
 ~~~~~~~~~~~~~~~~~~~~~
@@ -429,6 +447,12 @@ Merk: Bare en av objekttypene *klasse*, *mappe* eller *registrering* kan grupper
    - 0-1
    - A
    - Tekststreng
+ * - M711
+   - virksomhetsspesifikkeMetadata
+   - 
+   - 0-1
+   - A
+   - Vilkårlig struktur
 
 Metadata for *mappe*
 ~~~~~~~~~~~~~~~~~~~~
@@ -1337,6 +1361,12 @@ Merk: En *dokumentbeskrivelse* kan være knyttet til mer enn én enkelt *registr
    - 1
    - A
    - Tekststreng
+ * - M???
+   - eksternReferanse
+   - AM.REF
+   - 0-M
+   - Teststreng
+   - Ekstern referanse på innkommende dokumenter.
 
 Metadata for *sletting*
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1461,6 +1491,12 @@ Metadata for *dokumentobjekt*
    - 0-1
    - A
    - Tekststreng
+ * - M711
+   - virksomhetsspesifikkeMetadata
+   - 
+   - 0-1
+   - A
+   - Vilkårlig struktur
 
 Metadata for *konvertering*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
For å kunne hente ut all informasjon i et arkivsystem på en strukturert
måte, og ha fleksibiliteten til å ta vare på flere verdier enn det som
har egne standardiserte felter, så legges det inn støtte for feltet
virksomhetsspesifikkeMetadata på alle arkivenheter som i dag mangler det.

Legges inn i arkiv, arkivdel, klassifikasjonssystem, klasse og
dokumentobjekt.  Dette er en oppfølger til endringsforslag #96 der det
legges inn i dokumentbeskrivelse og korrespondansepart.