### PR TITLE
Samkjør datatype for M215 i metadatakatalog og objektsorterte metadata.

### DIFF
--- a/metadata/M215.yaml
+++ b/metadata/M215.yaml
@@ -1,7 +1,7 @@
 Arkivenhet: journalpost
 Arv: Nei
 Betingelser: Må inneholde gyldig systemID for registrering
-Datatype: Tekststreng
+Datatype: systemID
 Definisjon: Referanse til en eller flere journalposter som avskriver denne journalposten
 Gruppe: Referanser
 Kilde: Registreres manuelt eller automatisk ved avskrivning


### PR DESCRIPTION
Objektsortert liste og XSD sier datatypen er systemID, mens YAML-filen
sier tekststreng.  Endret YAML-filen.

Relatert til #24.