### PR TITLE
Korrigerte navn på M506 graderingskode i journalpost

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -2527,7 +2527,7 @@ Metadata for *journalpost*
    - A
    - Tekststreng
  * - M506
-   - gradering
+   - graderingskode
    - 
    - 0-1
    - A
@@ -2809,7 +2809,7 @@ Metadata for *journalpost*
    - A
    - Tekststreng
  * - M506
-   - gradering
+   - graderingskode
    - 
    - 0-1
    - A


### PR DESCRIPTION
Dette ble gjenglemt fra da metadatakatalogoppføringen endret navn
i 238c7c3aa06f0395b3da06ad0f10712ea656adb4.