### PR TITLE
Samkjør datatype for M037 fylkesnummer mellom YAML og objektsortert

### DIFF
--- a/metadata/M037.yaml
+++ b/metadata/M037.yaml
@@ -2,7 +2,7 @@ Arkivenhet: planident
 Arv: Nei
 Avleveres: A
 Betingelser:
-Datatype: Heltall
+Datatype: Tekststreng
 Definisjon: To-sifret kode som entydig identifiserer et fylke
 Gruppe: Nasjonale identifikatorer
 Kilde:


### PR DESCRIPTION
Fylkesnummer i objektsortert metadataliste og Noark 5 Tjenestegrensesnitt
er tekststreng, mens den var ført opp som heltall i YAML-filen.  Dette er
de to første tegnene i kommunenummer, som også er tekststreng, så jeg
tror tekstsstreng er korrekt.  Endret derfor YAML-filmen.

Relatert til #53.