### PR TITLE
Endret YAML-feltet Gjeldende til datobasert Utdatert

### DIFF
--- a/metadata/M001.yaml
+++ b/metadata/M001.yaml
@@ -5,7 +5,6 @@ Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Regex: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 Definisjon: Globalt unik identifikasjon av arkivenheten (UID).
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet
 Kommentarer: Alle referanser fra en arkivenhet til en annen skal peke til arkivenhetens
@@ -13,3 +12,4 @@ Kommentarer: Alle referanser fra en arkivenhet til en annen skal peke til arkive
   f.eks. mellom to arkivperioder som avleveres på forskjellig tidspunkt.
 Navn: systemID
 Nr: M001
+Utdatert: nei

--- a/metadata/M002.yaml
+++ b/metadata/M002.yaml
@@ -5,7 +5,6 @@ Arv: I hierarkiske klassifikasjonssystemer (f.eks. statens arkivnøkkel) skal en
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av klassen innenfor klassifikasjonssystemet.
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Alle klasser i et klassifikasjonssystem opprettes vanligvis når et arkivsystem
   tas i bruk. Men enkelte løsninger kan tillate at det opprettes nye klasser ved behov
@@ -16,3 +15,4 @@ Kommentarer: Ulike klassifikasjonssystemer innenfor samme arkivsystem kan inneho
   er identisk med begrepene ordningsverdi og arkivkode i Noark 4.
 Navn: klasseID
 Nr: M002
+Utdatert: nei

--- a/metadata/M003.yaml
+++ b/metadata/M003.yaml
@@ -4,7 +4,6 @@ Arv: Ja, til registrering, og aggregeres i *M004* *registreringsID* i kombinasjo
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av mappen innenfor det arkivet mappen tilhører.
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet etter interne regler
 Kommentarer: |-
@@ -13,3 +12,4 @@ Kommentarer: |-
   Er en videreføring av kombinasjonen saksår og sakssekvensnummer (oftest bare kalt "saksnummer") i Noark 4, som fortsatt er obligatorisk identifikasjon på saksmappe. I slike tilfeller skal verdien i mappeID også kopieres til de to metadataelementene *M011 saksaar* og *M012 sakssekvensnummer* i saksmappen.
 Navn: mappeID
 Nr: M003
+Utdatert: nei

--- a/metadata/M004.yaml
+++ b/metadata/M004.yaml
@@ -4,7 +4,6 @@ Betingelser: Skal normalt ikke kunne endres. Ved flytting til en annen mappe, ka
   endring av *registreringsID* forekomme.
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av registreringen innenfor arkivet.
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet etter interne regler
 Kommentarer: |-
@@ -13,3 +12,4 @@ Kommentarer: |-
   Er en videreføring av saksår og sakssekvensnummer (oftest bare kalt "saksnummer") i kombinasjon med "dokumentnummer" i Noark 4 (f.eks. 2011/3869-8, dvs. dokument nummer 8 i saksnummer 2011/3869), men trenger ikke ha denne formen for andre deler av arkivet.
 Navn: registreringsID
 Nr: M004
+Utdatert: nei

--- a/metadata/M005.yaml
+++ b/metadata/M005.yaml
@@ -5,10 +5,10 @@ Betingelser: Skal ikke endres. Den eldste versjonen skal ha det laveste nummeret
   "huller" i nummerrekkefølgen.
 Datatype: Heltall
 Definisjon: Identifikasjon av versjoner innenfor ett og samme dokument.
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når en ny versjon arkiveres
 Kommentarer: Versjonsnummer gjelder bare arkiverte versjoner. Annen versjons­håndtering
   ligger i komplett Noark, og genererer ikke metadata skal følge med i et arkivuttrekk.
 Navn: versjonsnummer
 Nr: M005
+Utdatert: nei

--- a/metadata/M006.yaml
+++ b/metadata/M006.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Unik ID for arkivskaperen
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres manuelt ved opprettelsen av arkivet
 Kommentarer: Kan være organisasjonsnummer (Brønnøysundregistrene) eller annen identifikasjon
   avtalt med arkivdepotet
 Navn: arkivskaperID
 Nr: M006
+Utdatert: nei

--- a/metadata/M007.yaml
+++ b/metadata/M007.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Identifikasjon av dokumentene innenfor en registrering
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet
 Kommentarer: Dokumentnummeret avgjør i hvilken rekkefølge dokumentene vises i brukergrensesnittet.
   Normalt skal hoveddokument vises før vedleggene.
 Navn: dokumentnummer
 Nr: M007
+Utdatert: nei

--- a/metadata/M008.yaml
+++ b/metadata/M008.yaml
@@ -4,9 +4,9 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Identifikasjon av møter som et utvalg har avholdt, viser rekkefølgene
   på møtene
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet, eventuelt også manuelt
 Kommentarer:
 Navn: moetenummer
 Nr: M008
+Utdatert: nei

--- a/metadata/M009.yaml
+++ b/metadata/M009.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: 
 Datatype: Tekststreng
 Definisjon: Rekkefølgenummer for  journalposter
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk av systemet når nye journalposter opprettes
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Det anbefales at løpenummer bygges opp av "journalår" og "sekvens-nummer" som i Noark 4. Metadataelementet styrer bl.a. sorteringsrekke-følgen i rapportene "Offentlig journal" og "Løpende journal".
 Navn: loepenummer
 Nr: M009
+Utdatert: nei

--- a/metadata/M010.yaml
+++ b/metadata/M010.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Unik ID for en part
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres manuelt når part opprettes
 Kommentarer: Kan være fødselsnummer eller annen personidentifikasjon
 Navn: partID
 Nr: M010
+Utdatert: nei

--- a/metadata/M011.yaml
+++ b/metadata/M011.yaml
@@ -3,9 +3,9 @@ Arv: Kopieres fra *M003 mappeID*
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Inngår i *M003 mappeID*. Viser året saksmappen ble opprettet.
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når saksmappen opprettes
 Kommentarer: Se kommentar under *M012 sakssekvensnummer*
 Navn: saksaar
 Nr: M011
+Utdatert: nei

--- a/metadata/M012.yaml
+++ b/metadata/M012.yaml
@@ -4,10 +4,10 @@ Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Inngår i *M003 mappeID*. Viser rekkefølgen når saksmappen ble opprettet
   innenfor året.
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når saksmappen opprettes
 Kommentarer: Kombinasjonen saksår og sakssekvensnummer er ikke obligatorisk, men anbefales
   brukt i sakarkiver.
 Navn: sakssekvensnummer
 Nr: M012
+Utdatert: nei

--- a/metadata/M013.yaml
+++ b/metadata/M013.yaml
@@ -3,9 +3,9 @@ Arv:
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Viser året journalposten ble opprettet
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når journalposten opprettes
 Kommentarer: Kombineres med *M014 journalsekvensnummer*, se kommentar under denne
 Navn: journalaar
 Nr: M013
+Utdatert: nei

--- a/metadata/M014.yaml
+++ b/metadata/M014.yaml
@@ -3,7 +3,6 @@ Arv:
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Viser rekkefølgen når journalposten ble opprettet under året
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når journalposten opprettes
 Kommentarer: |-
@@ -12,3 +11,4 @@ Kommentarer: |-
   Kombinasjonen journalår og sekvensnummer er ikke obligatorisk, men anbefales brukt i sakarkiver. Noen rapporter er sortert på denne kombinasjonen, f.eks. løpende- og offentlig journal. Dersom journalår og sekvensnummer ikke brukes, må kronologiske utskrifter sorteres etter andre kriterier (f.eks. journalpostens *opprettetDato*). I Noark 4 skulle sekvensnummeret vises før journalåret (f.eks. 25367/2011) for at det ikke skulle blandes sammen med saksnummeret som har året først.
 Navn: journalsekvensnummer
 Nr: M014
+Utdatert: nei

--- a/metadata/M015.yaml
+++ b/metadata/M015.yaml
@@ -5,7 +5,6 @@ Betingelser: Skal normalt ikke endres, men ved flytting til en annen saksmappe k
   denne mappen).
 Datatype: Heltall
 Definisjon: Viser rekkefølgen på journalpostene innenfor saksmappen,.
-Gjeldende: true
 Gruppe: Identifikasjon
 Kilde: Registreres automatisk når journalposten opprettes
 Kommentarer: Er ikke obligatorisk, men anbefales brukt i sakarkiver. Kombineres med
@@ -14,3 +13,4 @@ Kommentarer: Er ikke obligatorisk, men anbefales brukt i sakarkiver. Kombineres 
   saksmappen.
 Navn: journalpostnummer
 Nr: M015
+Utdatert: nei

--- a/metadata/M020.yaml
+++ b/metadata/M020.yaml
@@ -5,7 +5,6 @@ Betingelser: Skal normalt ikke kunne endres etter at enheten er lukket, eller do
   arkivert
 Datatype: Tekststreng
 Definisjon: Tittel eller navn på arkivenheten
-Gjeldende: true
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres manuelt eller hentes automatisk fra innholdet i arkivdokumentet.
   Ja fra klassetittel dersom alle mapper skal ha samme tittel som klassen. Kan også
@@ -14,3 +13,4 @@ Kommentarer: For saksmappe og journalpost vil dette tilsvare "Sakstittel" og "Do
   Disse navnene kan beholdes i grensesnittet.
 Navn: tittel
 Nr: M020
+Utdatert: nei

--- a/metadata/M021.yaml
+++ b/metadata/M021.yaml
@@ -4,10 +4,10 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Tekstlig beskrivelse av arkivenheten
-Gjeldende: true
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres manuelt
 Kommentarer: Tilsvarende attributt finnes ikke i Noark 4 (men noen tabeller hadde
   egne attributter for merknad som kunne brukes som et beskrivelsesfelt)
 Navn: beskrivelse
 Nr: M021
+Utdatert: nei

--- a/metadata/M022.yaml
+++ b/metadata/M022.yaml
@@ -3,7 +3,6 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Nøkkeord eller stikkord som beskriver innholdet i enheten
-Gjeldende: true
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres vanligvis ved oppslag fra liste (f.eks. en tesaurus). Kan også
   registreres automatisk på grunnlag av dokumentinnhold eller integrering med fagsystem.
@@ -11,3 +10,4 @@ Kommentarer: Nøkkelord kan brukes for å forbedre mulighetene for søking og gj
   Nøkkelord skal ikke erstatte klassifikasjon.
 Navn: noekkelord
 Nr: M022
+Utdatert: nei

--- a/metadata/M023.yaml
+++ b/metadata/M023.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på organisasjonen som har skapt arkivet
-Gjeldende: true
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres manuelt ved opprettelsen av arkivet.
 Kommentarer:
 Navn: arkivskaperNavn
 Nr: M023
+Utdatert: nei

--- a/metadata/M024.yaml
+++ b/metadata/M024.yaml
@@ -4,7 +4,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person (eller eventuelt organisasjon) som har forfattet eller
   skapt dokumentet.
-Gjeldende: true
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde: Registreres automatisk av systemet, automatisk fra innholdet i dokumentet eller
   manuelt
@@ -16,3 +15,4 @@ Kommentarer: Sakarkiver har tradisjonelt ikke noen forfatter på journalposten, 
   erstattes med en kilde (f.eks. et system).
 Navn: forfatter
 Nr: M024
+Utdatert: nei

--- a/metadata/M025.yaml
+++ b/metadata/M025.yaml
@@ -5,10 +5,10 @@ Betingelser: Obligatorisk i arkivuttrekk dersom tittelen inneholder ord som skal
 Datatype: Tekststreng
 Definisjon: Offentlig tittel på arkivenheten, ord som skal skjermes er fjernet fra
   innholdet i tittelen (erstattet med ******)
-Gjeldende: true
 Gruppe: Kjernemetadata (jf. Dublin Core)
 Kilde:
 Kommentarer: I løpende og offentlig journaler skal også offentligTittel være med dersom
   ord i tittelfeltet skal skjermes.
 Navn: offentligTittel
 Nr: M025
+Utdatert: nei

--- a/metadata/M030.yaml
+++ b/metadata/M030.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Firesifret kode som entydig identifiserer en kommune
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: De to første sifrene identifiserer fylke og de to siste identifiserer kommunen innefor fylket. Tildeles av SSB.
 Navn: kommunenummer
 Nr: M030
+Utdatert: nei

--- a/metadata/M031.yaml
+++ b/metadata/M031.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Heltall
 Definisjon: Nummerering av gårdsenhet i matrikkelen, nummeret er unikt innenfor kommunen
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: "SOSI-format-navn/datatype/lengde: GNR/H/5."
 Navn: gaardsnummer
 Nr: M031
+Utdatert: nei

--- a/metadata/M032.yaml
+++ b/metadata/M032.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Heltall
 Definisjon: Fortløpende nummerering av bruk under gårdsnummer
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: "SOSI-format-navn/datatype/lengde: BNR/H/4"
 Navn: bruksnummer
 Nr: M032
+Utdatert: nei

--- a/metadata/M033.yaml
+++ b/metadata/M033.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Heltall
 Definisjon: Fortløpende nummerering av fester under gårdsnummer/bruksnummer
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: "Underoppdeling under bruksnummer, angir enheter som kan omsettes og pantsettes. Del av matrikkelnummeret som identifiserer festegrunn (tomt). Tas i bruk når et bruksnummer skal deles opp i flere grunneiendommer. SOSI-format-navn/datatype/lengde: FNR/H/4."
 Navn: festenummer
 Nr: M033
+Utdatert: nei

--- a/metadata/M034.yaml
+++ b/metadata/M034.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Heltall
 Definisjon: Fortløpende nummerering av seksjoner under gårdsnummer/bruksnummer og eventuelt festenummer
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: "Underoppdeling under bruksnummer, angir enheter som kan omsettes og selges. Typisk i leilighetesbygg i flere etasjer, forretningsgårder eller en blanding av forretninger og leiligheter. SOSI-format-navn/datatype/lengde: SNR/H/3."
 Navn: seksjonsnummer
 Nr: M034
+Utdatert: nei

--- a/metadata/M035.yaml
+++ b/metadata/M035.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Heltall
 Definisjon: Entydig identifikasjon av bygning i matrikkelen
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: "Bygningsnumrene er unike på landsbasis, og tildeles automatisk. SOSI-format-navn/datatype/lengde: BYGGNR/H/9"
 Navn: bygningsnummer
 Nr: M035
+Utdatert: nei

--- a/metadata/M036.yaml
+++ b/metadata/M036.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Heltall
 Definisjon: Entydig identifikasjon av endring av bygning i matrikkelen
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: "Løpende nummerering av bygningsendringer til en bygning. SOSI-format-navn/datatype/lengde: BYGN_ENDR_LØPENR/H/2 Denne kan utelates når det kun er bygningen som skal identifiseres."
 Navn: endringsloepenummer
 Nr: M036
+Utdatert: nei

--- a/metadata/M037.yaml
+++ b/metadata/M037.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Heltall
 Definisjon: To-sifret kode som entydig identifiserer et fylke
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer:
 Navn: fylkesnummer
 Nr: M037
+Utdatert: nei

--- a/metadata/M038.yaml
+++ b/metadata/M038.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av et land
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: To-bokstavs kode i hht. ISO 3166
 Navn: landkode
 Nr: M038
+Utdatert: nei

--- a/metadata/M039.yaml
+++ b/metadata/M039.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon for en plan innen en kommune eller et fylke
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: Jf. pbl. 1985 § 18, § 19-1 sjette ledd, § 20-1 andre og femte ledd og § 22 og § 28-2/pbl. §§ 6-4, 8-1, 9-1, 11-1 og § 12-1, samt kart- og planforskriften § 9 andre og sjette ledd
 Navn: planidentifikasjon
 Nr: M039
+Utdatert: nei

--- a/metadata/M040.yaml
+++ b/metadata/M040.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Østlig koordinat for et geografisk punkt
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: Østlig UTM-koordinat for et punkt, definisjonen er avhengig av valgt koordinatsystem.
 Navn: x
 Nr: M040
+Utdatert: nei

--- a/metadata/M041.yaml
+++ b/metadata/M041.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Nordlig koordinat for et geografisk punkt
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: Nordlig UTM-koordinat for et punkt, definisjonen er avhengig av valgt koordinatsystem.
 Navn: y
 Nr: M041
+Utdatert: nei

--- a/metadata/M042.yaml
+++ b/metadata/M042.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Høyden til et geografisk punkt
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: Høyde avhenger av koordinatsystemet (f.eks. høyde over havet eller høyde vs. overflaten).
 Navn: z
 Nr: M042
+Utdatert: nei

--- a/metadata/M043.yaml
+++ b/metadata/M043.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Geografiske koordinaters referansesystem
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: Koordinatsystem for geografisk punkt, flate etc. Normalt en kode angitt som EPSG:nnnnn hvor nnnnn er 32632 (Sør-Norge), 32633 (Nord-Norge, Norge generelt) og 32635 (Finnmark). Kan også være en kode som EUREFSonenn der nn normalt er 32, 33 eller 35.
 Navn: koordinatsystem
 Nr: M043
+Utdatert: nei

--- a/metadata/M048.yaml
+++ b/metadata/M048.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av en person
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: For norske eller utenlandske personer med midlertidig opphold i Norge, fødselsnummer eller d-nummer fra Folkeregisteret. For utenlandske personer, to-bokstavers landkode i hht. ISO 3166 etterfulgt av skråstrek etterfulgt av nasjonal person-identifikator.
 Navn: personID
 Nr: M048
+Utdatert: nei

--- a/metadata/M049.yaml
+++ b/metadata/M049.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av en organisasjon
-Gjeldende: true
 Gruppe: Nasjonale identifikatorer
 Kilde:
 Kommentarer: For norske organisasjoner, organisasjonsnummer fra Enhetsregisteret. For utenlandske organisasjoner, firesifret landkode i hht. ISO 6523 etterfulgt av kolon etterfulgt av nasjonal organisasjons-identifikator.
 Navn: organisasjonsID
 Nr: M049
+Utdatert: nei

--- a/metadata/M050.yaml
+++ b/metadata/M050.yaml
@@ -9,9 +9,9 @@ Betingelser: |-
   Skifte av status kan bare utføres av autoriserte personer.
 Datatype: Tekststreng
 Definisjon: Status til arkivet
-Gjeldende: true
 Gruppe: Status
 Kilde: Registreres manuelt når arkivet opprettes eller ved skifte av status.
 Kommentarer:
 Navn: arkivstatus
 Nr: M050
+Utdatert: nei

--- a/metadata/M051.yaml
+++ b/metadata/M051.yaml
@@ -11,9 +11,9 @@ Betingelser: |-
   Skifte av status kan bare utføres av autoriserte personer.
 Datatype: Tekststreng
 Definisjon: Status til den arkivperioden som arkivdelen omfatter
-Gjeldende: true
 Gruppe: Status
 Kilde: Registreres manuelt når arkivdelen opprettes eller ved skifte av status.
 Kommentarer: Arkivdeler som avleveres skal ha status "Avsluttet periode"
 Navn: arkivdelstatus
 Nr: M051
+Utdatert: nei

--- a/metadata/M052.yaml
+++ b/metadata/M052.yaml
@@ -10,10 +10,10 @@ Betingelser: |-
   Skifte av status kan bare utføres av autoriserte personer.
 Datatype: Tekststreng
 Definisjon: Status til saksmappen, dvs. hvor langt saksbehandlingen har kommet.
-Gjeldende: true
 Gruppe: Status
 Kilde: Registreres automatisk gjennom forskjellig saksbehandlings­funksjonalitet,
   eller overstyres manuelt.
 Kommentarer: Saksmapper som avleveres skal ha status "Avsluttet" eller "Utgår".
 Navn: saksstatus
 Nr: M052
+Utdatert: nei

--- a/metadata/M053.yaml
+++ b/metadata/M053.yaml
@@ -12,10 +12,10 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Status til journalposten, dvs. om dokumentet er registrert, under behandling
   eller endelig arkivert.
-Gjeldende: true
 Gruppe: Status
 Kilde: Registreres automatisk gjennom forskjellig saksbehandlings­funksjonalitet,
   eller overstyres manuelt.
 Kommentarer: Journalposter som avleveres skal ha status "Arkivert" eller "Utgår".
 Navn: journalstatus
 Nr: M053
+Utdatert: nei

--- a/metadata/M054.yaml
+++ b/metadata/M054.yaml
@@ -7,9 +7,9 @@ Betingelser: |-
   - "Dokumentet er ferdigstilt"
 Datatype: Tekststreng
 Definisjon: Status til dokumentet
-Gjeldende: true
 Gruppe: Status
 Kilde: Kan endres automatisk ved endring i saksstatus eller journalstatus.
 Kommentarer: Dokumentbeskrivelser som avlevers skal ha status "Dokumentet er ferdigstilt".
 Navn: dokumentstatus
 Nr: M054
+Utdatert: nei

--- a/metadata/M055.yaml
+++ b/metadata/M055.yaml
@@ -8,9 +8,9 @@ Betingelser: |-
   - "Sendt tilbake til foregående utvalg"
 Datatype: Tekststreng
 Definisjon: Status til møteregistreringen
-Gjeldende: true
 Gruppe: Status
 Kilde:
 Kommentarer:
 Navn: moeteregistreringsstatus
 Nr: M055
+Utdatert: nei

--- a/metadata/M056.yaml
+++ b/metadata/M056.yaml
@@ -7,9 +7,9 @@ Betingelser: |-
   - "Foreldet"
 Datatype: Tekststreng
 Definisjon: Informasjon om presedensen er gjeldende eller foreldet
-Gjeldende: true
 Gruppe: Status
 Kilde: Registreres manuelt ved foreldelse
 Kommentarer:
 Navn: presedensstatus
 Nr: M056
+Utdatert: nei

--- a/metadata/M082.yaml
+++ b/metadata/M082.yaml
@@ -10,9 +10,9 @@ Betingelser: |-
   - "Saksframlegg"
 Datatype: Tekststreng
 Definisjon: Navn på type journalpost
-Gjeldende: true
 Gruppe: Typer
 Kilde: Registreres automatisk av systemet eller manuelt
 Kommentarer: Tilsvarer "Noark dokumenttype" i Noark 4
 Navn: journalposttype
 Nr: M082
+Utdatert: nei

--- a/metadata/M083.yaml
+++ b/metadata/M083.yaml
@@ -9,9 +9,9 @@ Betingelser: |-
   - "Ordrebekreftelser"
 Datatype: Tekststreng
 Definisjon: Navn på type dokument
-Gjeldende: true
 Gruppe: Typer
 Kilde: Registreres automatisk av systemet eller manuelt
 Kommentarer:
 Navn: dokumenttype
 Nr: M083
+Utdatert: nei

--- a/metadata/M084.yaml
+++ b/metadata/M084.yaml
@@ -8,9 +8,9 @@ Betingelser: |-
   - "Merknad fra arkivansvarlig"
 Datatype: Tekststreng
 Definisjon: Navn på type merknad
-Gjeldende: true
 Gruppe: Typer
 Kilde:
 Kommentarer:
 Navn: merknadstype
 Nr: M084
+Utdatert: nei

--- a/metadata/M085.yaml
+++ b/metadata/M085.yaml
@@ -9,9 +9,9 @@ Betingelser: |-
   - "Vedlegg til møtesak"
 Datatype: Tekststreng
 Definisjon: Navn på type møteregistrering
-Gjeldende: true
 Gruppe: Typer
 Kilde:
 Kommentarer:
 Navn: moeteregistreringstype
 Nr: M085
+Utdatert: nei

--- a/metadata/M086.yaml
+++ b/metadata/M086.yaml
@@ -13,9 +13,9 @@ Betingelser: |-
   - "Gårds- og bruksnummer"
 Datatype: Tekststreng
 Definisjon: Type klassifikasjonssystem
-Gjeldende: true
 Gruppe: Typer
 Kilde: Registreres manuelt ved opprettelse av *klassifikasjonssystem*
 Kommentarer:
 Navn: klassifikasjonstype
 Nr: M086
+Utdatert: nei

--- a/metadata/M087.yaml
+++ b/metadata/M087.yaml
@@ -11,7 +11,6 @@ Betingelser: |-
   - "Intern mottaker"
 Datatype: Tekststreng
 Definisjon: Type korrespondansepart
-Gjeldende: true
 Gruppe: Typer
 Kilde: Registreres automatisk knyttet til funksjonalitet i forbindelse med opprettelse
   av journalpost, kan også registreres manuelt
@@ -19,3 +18,4 @@ Kommentarer: Korrespondansetype forekommer én gang innenfor objektet korrespond
   men denne kan forekomme flere ganger innenfor en journalpost.
 Navn: korrespondanseparttype
 Nr: M087
+Utdatert: nei

--- a/metadata/M088.yaml
+++ b/metadata/M088.yaml
@@ -9,9 +9,9 @@ Betingelser: |-
   - "Interpellasjon"
 Datatype: Tekststreng
 Definisjon: Navn på type møtesak
-Gjeldende: true
 Gruppe: Typer
 Kilde:
 Kommentarer:
 Navn: moetesakstype
 Nr: M088
+Utdatert: nei

--- a/metadata/M089.yaml
+++ b/metadata/M089.yaml
@@ -8,10 +8,10 @@ Betingelser: |-
   - "Sletting av variant med sladdet informasjon"
 Datatype: Tekststreng
 Definisjon: Navn på hvilket objekt som er slettet
-Gjeldende: true
 Gruppe: Typer
 Kilde:
 Kommentarer: Siste versjon av et dokument skal vanligvis ikke kunne slettes. Sletting
   av innholdet i en arkivdel skal bare kunne utføres av autorisert personale.
 Navn: slettingstype
 Nr: M089
+Utdatert: nei

--- a/metadata/M100.yaml
+++ b/metadata/M100.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal kunne endres manuelt inntil saksmappen avsluttes
 Datatype: Dato og klokkeslett
 Definisjon: Datoen saken er opprettet
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Settes automatisk til samme dato som *M600 opprettetDato*
 Kommentarer:
 Navn: saksdato
 Nr: M100
+Utdatert: nei

--- a/metadata/M101.yaml
+++ b/metadata/M101.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal kunne endres manuelt inntil arkivering
 Datatype: Dato og klokkeslett
 Definisjon: Datoen journalposten er journalført
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Settes automatisk når journalstatus settes til journalført.
 Kommentarer:
 Navn: journaldato
 Nr: M101
+Utdatert: nei

--- a/metadata/M102.yaml
+++ b/metadata/M102.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal kunne endres manuelt inntil mappen avsluttes.
 Datatype: Dato og klokkeslett
 Definisjon: Datoen når et utvalgsmøte blir avholdt
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres manuelt ved opprettelsen av en møtemappe.
 Kommentarer:
 Navn: moetedato
 Nr: M102
+Utdatert: nei

--- a/metadata/M103.yaml
+++ b/metadata/M103.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal kunne endres manuelt inntil arkivering
 Datatype: Dato og klokkeslett
 Definisjon: Dato som er påført selve dokumentet
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Datoen hentes automatisk fra dokumentet, eller registreres manuelt
 Kommentarer: Kan brukes både for inngående, utgående og organinterne dokumenter
 Navn: dokumentetsDato
 Nr: M103
+Utdatert: nei

--- a/metadata/M104.yaml
+++ b/metadata/M104.yaml
@@ -4,9 +4,9 @@ Betingelser: Skal ikke kunne endres ved automatisk registrering, dato for mottak
   fysiske dokumenter skal kunne endres inntil arkivering
 Datatype: Dato og klokkeslett
 Definisjon: Dato et eksternt dokument ble mottatt
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres manuelt eller automatisk av systemet ved elektronisk kommunikasjon
 Kommentarer: Merk at mottattDato ikke behøver å være identisk med *M600 opprettetDato*
 Navn: mottattDato
 Nr: M104
+Utdatert: nei

--- a/metadata/M105.yaml
+++ b/metadata/M105.yaml
@@ -4,9 +4,9 @@ Betingelser: Skal ikke kunne endres ved automatisk registrering, dato for forsen
   av fysiske dokumenter skal kunne endres inntil arkivering
 Datatype: Dato og klokkeslett
 Definisjon: Dato et internt produsert dokument ble sendt/ekspedert
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres manuelt eller automatisk av systemet ved elektronisk kommunikasjon
 Kommentarer:
 Navn: sendtDato
 Nr: M105
+Utdatert: nei

--- a/metadata/M106.yaml
+++ b/metadata/M106.yaml
@@ -4,7 +4,6 @@ Betingelser: Utlån skal også kunne registreres etter at en saksmappe er avslut
   eller etter at dokumentene i en journalpost ble arkivert.
 Datatype: Dato og klokkeslett
 Definisjon: Dato når en fysisk saksmappe eller journalpost ble utlånt
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres manuelt ved utlån
 Kommentarer: Det er ikke spesifisert noen dato for tilbakelevering. Tilbakelevering
@@ -12,3 +11,4 @@ Kommentarer: Det er ikke spesifisert noen dato for tilbakelevering. Tilbakelever
   logging av utlån av fysiske dokumenter.
 Navn: utlaantDato
 Nr: M106
+Utdatert: nei

--- a/metadata/M107.yaml
+++ b/metadata/M107.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser: Skal kunne endres manuelt
 Datatype: Dato og klokkeslett
 Definisjon: Dato for starten av en arkivperiode
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Settes automatisk til samme dato som *M600 opprettetDato*
 Kommentarer: Det kan tenkes tilfeller hvor startdatoen ikke er identisk med datoen
   arkivdelen ble opprettet
 Navn: arkivperiodeStartDato
 Nr: M107
+Utdatert: nei

--- a/metadata/M108.yaml
+++ b/metadata/M108.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser: Skal kunne endres manuelt.
 Datatype: Dato og klokkeslett
 Definisjon: Dato for slutten av en arkivperiode
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Settes automatisk til samme dato som *M602 avsluttetDato*
 Kommentarer: Det kan forekomme tilfeller hvor sluttdatoen ikke er identisk med datoen
   arkivdelen ble avsluttet.
 Navn: arkivperiodeSluttDato
 Nr: M108
+Utdatert: nei

--- a/metadata/M109.yaml
+++ b/metadata/M109.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato som angir fristen for når et inngående dokument må være besvart
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres manuelt
 Kommentarer: Forfallsdato kan være angitt som en betingelse i det inngående dokumentet
 Navn: forfallsdato
 Nr: M109
+Utdatert: nei

--- a/metadata/M110.yaml
+++ b/metadata/M110.yaml
@@ -3,7 +3,6 @@ Arv: Nei
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Datoen da offentlighetsvurdering ble foretatt
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres automatisk knyttet til funksjonalitet for skjerming
 Kommentarer: Dato for offentlighetsvurdering kan brukes dersom inngående dokumenter
@@ -11,3 +10,4 @@ Kommentarer: Dato for offentlighetsvurdering kan brukes dersom inngående dokume
   på et litt senere tidspunkt.
 Navn: offentlighetsvurdertDato
 Nr: M110
+Utdatert: nei

--- a/metadata/M111.yaml
+++ b/metadata/M111.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Datoen på presedensen
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres manuelt ved opprettelse av presedens, men bør også kunne hentes
   automatisk fra *M103 dokumentetsDato* på journalposten presedensen opprettes på.
 Kommentarer:
 Navn: presedensDato
 Nr: M111
+Utdatert: nei

--- a/metadata/M112.yaml
+++ b/metadata/M112.yaml
@@ -4,9 +4,9 @@ Arv:
 Betingelser: Startdato skal selekteres på *M101 journaldato*
 Datatype: Dato og klokkeslett
 Definisjon: Startdato for journalutskriftene som inngår i avleveringspakken.
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres når avleveringspakken produseres
 Kommentarer: Startdatoen vil vanligvis være identisk med *M107 arkivperiodeStartdato*
 Navn: journalStartDato
 Nr: M112
+Utdatert: nei

--- a/metadata/M113.yaml
+++ b/metadata/M113.yaml
@@ -4,9 +4,9 @@ Arv:
 Betingelser: Sluttdato skal selekteres på *M101 journaldato*
 Datatype: Dato og klokkeslett
 Definisjon: Sluttdato for journalutskriftene som inngår i avleveringspakken.
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres når avleveringspakken produseres
 Kommentarer: Sluttdatoen vil vanligvis være identisk med *M108 arkivperiodeSluttdato*
 Navn: journalSluttDato
 Nr: M113
+Utdatert: nei

--- a/metadata/M114.yaml
+++ b/metadata/M114.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Startdatoen kan selekteres på M602 avsluttetDato for mappen. Andre seleksjonskriterier kan være aktuelle.
 Datatype: Dato
 Definisjon: Startdato avleveringspakken.
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres når avleveringspakken produseres
 Kommentarer: Startdatoen vil være identisk med M107 arkivperiodeStartdato dersom uttrekket bare omfatter en avleveringspakke.
 Navn: avleveringspakkeStartDato
 Nr: M114
+Utdatert: nei

--- a/metadata/M115.yaml
+++ b/metadata/M115.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Sluttdatoen kan selekteres på M602 avsluttetDato for mappen. Andre seleksjonskriterier kan være aktuelle.
 Datatype: Dato
 Definisjon: Sluttdato for avleveringspakken.
-Gjeldende: true
 Gruppe: Datoer
 Kilde: Registreres når avleveringspakken produseres
 Kommentarer: Sluttdatoen vil være identisk med M108 arkivperiodeSluttdato dersom uttrekket bare omfatter en avleveringspakke.
 Navn: avleveringspakkeSluttDato
 Nr: M115
+Utdatert: nei

--- a/metadata/M200.yaml
+++ b/metadata/M200.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres. 
 Datatype: systemID
 Definisjon: Referanse til den arkivenheten i hierarkiet som er direkte overordnet denne arkivenheten
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk av systemet
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Er obligatorisk for arkiv bare dersom denne enheten er et underarkiv (delarkiv). Ved klasse kan forelder både være en annen klasse eller et klassifikasjonssystem. Ved mappe kan forelder være på en annen overordnet mappe eller en klasse. Dersom mappenivået utelates, kan forelder til en registrering være en klasse.
 Navn: referanseForelder
 Nr: M200
+Utdatert: nei

--- a/metadata/M201.yaml
+++ b/metadata/M201.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres.
 Datatype: systemID
 Definisjon: Referanse til den eller de arkivenhetene i hierarkiet som er direkte underordnet denne arkivenheten
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk av systemet
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Ved klasse kan barn være en/flere klasse(r) eller en/flere mappe(r). Dersom mappenivået utelates, kan det også være en/flere registrering(er). Ved mappe kan barn være en en/flere undermappe(r) eller en/flere registrering(er).
 Navn: referanseBarn
 Nr: M201
+Utdatert: nei

--- a/metadata/M202.yaml
+++ b/metadata/M202.yaml
@@ -4,9 +4,9 @@ Betingelser:
 Datatype: systemID
 Definisjon: Referanse til den arkivdelen som er forløper for denne arkivdelen, dvs.
   inneholder forrige arkivperiode.
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk når arkivdelen som er arvtaker opprettes
 Kommentarer:
 Navn: referanseForloeper
 Nr: M202
+Utdatert: nei

--- a/metadata/M203.yaml
+++ b/metadata/M203.yaml
@@ -4,10 +4,10 @@ Betingelser:
 Datatype: systemID
 Definisjon: Referanse til den arkivdelen som er arvtaker for denne arkivdelen, dvs.
   inneholder neste arkivperiode.
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk når det opprettes en arkivdel som defineres som arvtaker
   til en eksisterende arkivdel
 Kommentarer:
 Navn: referanseArvtaker
 Nr: M203
+Utdatert: nei

--- a/metadata/M204.yaml
+++ b/metadata/M204.yaml
@@ -4,9 +4,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til det klassifikasjonssystemet som mappene i denne arkivdelen er klassifisert etter
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres manuelt når arkivdelen opprettes
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: referanseKlassifikasjonssystem
 Nr: M204
+Utdatert: nei

--- a/metadata/M205.yaml
+++ b/metadata/M205.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til  mapper som tilhører en arkivdel
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk når mapper opprettes
 Kommentarer: NB! Gyldig t.o.m. Versjon 2.1
 Navn: referanseMappe
 Nr: M205  
+Utdatert: nei

--- a/metadata/M206.yaml
+++ b/metadata/M206.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til registreringer som er knyttet til denne enheten
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk når registreringer opprettes
 Kommentarer: NB! Gyldig t.o.m. Versjon 2.1. En og samme dokumentbeskrivelse kan være knyttet til flere registreringer (det er et M:M forhold mellom registrering og dokumentbeskrivelse). En arkivdel kan være direkte knyttet til en eller flere registreringer (f.eks. aktuelt ved kassasjon av bestemte typer  dokumenter).  Referansen er også aktuell i fagsystemer som verken inneholder mapper eller et klassifikasjonssystem.
 Navn: referanseRegistrering
 Nr: M206  
+Utdatert: nei

--- a/metadata/M207.yaml
+++ b/metadata/M207.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til dokumentbeskrivelser som tilknyttet denne arkivenheten
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk når dokumentbeskrivelser opprettes
 Kommentarer: NB! Gyldig t.o.m. Versjon 2.1
 Navn: referanseDokumentbeskrivelse
 Nr: M207
+Utdatert: nei

--- a/metadata/M208.yaml
+++ b/metadata/M208.yaml
@@ -3,7 +3,6 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til arkivdelen som denne arkivenheten er tilknyttet
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk, kan overstyres manuelt
 Kommentarer: 'Alle mapper skal ha referanse til arkivdel (selv om tilhørigheten til
@@ -22,3 +21,4 @@ Kommentarer: 'Alle mapper skal ha referanse til arkivdel (selv om tilhørigheten
   opprettes.'
 Navn: referanseArkivdel
 Nr: M208
+Utdatert: nei

--- a/metadata/M209.yaml
+++ b/metadata/M209.yaml
@@ -4,10 +4,10 @@ Betingelser:
 Datatype: systemID
 Definisjon: Referanse til sekundærklassifikasjon. Kan også referere til flere enn
   én sekundær klassifikasjon (tertiærklassifikasjon osv.)
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk ved klassifikasjon
 Kommentarer: Kan også brukes for å bygge opp mangefasettert klassifikasjon og kommunenes
   klassifikasjonssystem "K-kodene".
 Navn: referanseSekundaerKlassifikasjon
 Nr: M209
+Utdatert: nei

--- a/metadata/M210.yaml
+++ b/metadata/M210.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse til en *mappe* fra en annen *mappe* eller *registrering*
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk når kryssreferanse opprettes
 Kommentarer:
 Navn: referanseTilMappe
 Nr: M210
+Utdatert: nei

--- a/metadata/M211.yaml
+++ b/metadata/M211.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse fra en mappe til en annen mappe eller registrering
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk når kryssreferanse opprettes
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: referanseFraMappe
 Nr: M211
+Utdatert: nei

--- a/metadata/M212.yaml
+++ b/metadata/M212.yaml
@@ -4,9 +4,9 @@ Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse til en *registrering* fra en annen *registrering* eller
   *mappe*
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk når en kryssreferanse opprettes
 Kommentarer:
 Navn: referanseTilRegistrering
 Nr: M212
+Utdatert: nei

--- a/metadata/M213.yaml
+++ b/metadata/M213.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse fra en registrering til en annen registrering eller saksmappe
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk når kryssreferanse opprettes
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: referanseFraRegistrering
 Nr: M213
+Utdatert: nei

--- a/metadata/M214.yaml
+++ b/metadata/M214.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til en eller flere journalposter som blir avskrevet av denne journalposten
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres manuelt eller automatisk ved avskrivning
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: referanseAvskriverJournalpost
 Nr: M214
+Utdatert: nei

--- a/metadata/M215.yaml
+++ b/metadata/M215.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til en eller flere journalposter som avskriver denne journalposten
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres manuelt eller automatisk ved avskrivning
 Kommentarer:
 Navn: referanseAvskrivesAvJournalpost
 Nr: M215
+Utdatert: nei

--- a/metadata/M216.yaml
+++ b/metadata/M216.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til dokumentobjektet
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk når et eller flere dokumenter knyttes til en registrering
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Dersom registreringen bare består av ett dokument, kan referansen gå direkte fra registrering til dokumentobjekt
 Navn: referanseDokumentobjekt
 Nr: M216
+Utdatert: nei

--- a/metadata/M217.yaml
+++ b/metadata/M217.yaml
@@ -7,9 +7,9 @@ Betingelser: |-
   - "Vedlegg"
 Datatype: Tekststreng
 Definisjon: Angivelse av hvilken "rolle" dokumentet har i forhold til registreringen
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk eller manuelt når et dokument blir tilknyttet en registrering
 Kommentarer:
 Navn: tilknyttetRegistreringSom
 Nr: M217
+Utdatert: nei

--- a/metadata/M218.yaml
+++ b/metadata/M218.yaml
@@ -4,7 +4,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til filen som inneholder det elektroniske dokumentet som dokumentobjektet
   beskriver
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk når et dokument tilknyttes en registrering, når det
   arkiveres flere versjoner av et dokument, når det lages en egen variant av dokumentet
@@ -14,3 +13,4 @@ Kommentarer: Referansen skal være en "sti" (dvs. også inneholde katalogstruktu
   skal angis relativt i forhold til filen *arkivstruktur.xml*.
 Navn: referanseDokumentfil
 Nr: M218
+Utdatert: nei

--- a/metadata/M219.yaml
+++ b/metadata/M219.yaml
@@ -3,7 +3,6 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til en annen klasse
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres vanligvis manuelt når klassifikasjonssystemet opprettes
 Kommentarer: Kryssreferansen kan gå til en eller flere klasser innenfor samme klassifikasjonssystem,
@@ -11,3 +10,4 @@ Kommentarer: Kryssreferansen kan gå til en eller flere klasser innenfor samme k
   sammen beslektede klasser som ikke kan utledes fra det hierarkiske klassifikasjonssystemet.
 Navn: referanseTilKlasse
 Nr: M219
+Utdatert: nei

--- a/metadata/M220.yaml
+++ b/metadata/M220.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse fra en annen klasse
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres manuelt
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Kryssreferansen kan gå til en eller flere klasser innenfor samme klassifikasjonssystem, og til en eller flere klasser i andre klassifikasjonssystem
 Navn: referanseFraKlasse
 Nr: M220
+Utdatert: nei

--- a/metadata/M221.yaml
+++ b/metadata/M221.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til forrige utvalgsmøte
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres manuelt
 Kommentarer: Kan brukes dersom et møte går over flere dager
 Navn: referanseForrigeMoete
 Nr: M221
+Utdatert: nei

--- a/metadata/M222.yaml
+++ b/metadata/M222.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til neste utvalgsmøte
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres manuelt
 Kommentarer: Kan brukes dersom et møte går over flere dager
 Navn: referanseNesteMoete
 Nr: M222
+Utdatert: nei

--- a/metadata/M223.yaml
+++ b/metadata/M223.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til en annen møteregistrering
-Gjeldende: true
 Gruppe: Referanser
 Kilde:
 Kommentarer: Kan brukes for å knytte sammen dokumenter som tilhører samme "møtesak"
   (Møtemappen har ikke noe eget nivå for møtesaker.)
 Navn: referanseTilMoeteregistrering
 Nr: M223
+Utdatert: nei

--- a/metadata/M224.yaml
+++ b/metadata/M224.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse fra en annen møteregistrering
-Gjeldende: true
 Gruppe: Referanser
 Kilde:
 Kommentarer: Kan brukes for å knytte sammen dokumenter som tilhører samme "møtesak"
 Navn: referanseFraMoeteregistrering
 Nr: M224
+Utdatert: nei

--- a/metadata/M225.yaml
+++ b/metadata/M225.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Obligatorisk ved bruk av Noark 5 tjenestegrensesnitt
 Datatype: systemID
 Definisjon: Referanse til bruker som opprettet/registrerte arkivenheten
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: referanseOpprettetAv
 Nr: M225
+Utdatert: nei

--- a/metadata/M226.yaml
+++ b/metadata/M226.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til bruker som oppdaterte arkivenheten
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: referanseOppdatertAv
 Nr: M226
+Utdatert: nei

--- a/metadata/M227.yaml
+++ b/metadata/M227.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivenheten er avsluttet. Obligatorisk ved bruk av Noark 5 tjenestegrensesnitt.
 Datatype: systemID
 Definisjon: Referanse til bruker som avsluttet/lukket arkivenheten
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: referanseAvsluttetAv
 Nr: M227
+Utdatert: nei

--- a/metadata/M228.yaml
+++ b/metadata/M228.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til bruker som arkiverte arkivenheten
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk av systemet ved arkivering av enheten
 Kommentarer:
 Navn: referanseArkivertAv
 Nr: M228
+Utdatert: nei

--- a/metadata/M229.yaml
+++ b/metadata/M229.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til overordnet mappe
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk av systemet ved arkivering av enheten
 Kommentarer:
 Navn: referanseForelderMappe
 Nr: M229
+Utdatert: nei

--- a/metadata/M230.yaml
+++ b/metadata/M230.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: systemID
 Definisjon: Referanse til bruker som oppdaterte arkivenheten eller endret metadata
-Gjeldende: true
 Gruppe: Referanser
 Kilde: Registreres automatisk ved oppdatering av en arkivenhet eller endring av metadata
 Kommentarer: Erstatter M226 referanseOppdatertAv
 Navn: referanseEndretAv
 Nr: M230
+Utdatert: nei

--- a/metadata/M300.yaml
+++ b/metadata/M300.yaml
@@ -9,7 +9,6 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av om arkivenheten inneholder fysiske dokumenter, elektroniske
   dokumenter eller en blanding av fysiske og elektroniske dokumenter
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Arves fra overordnet nivå, kan overstyres manuelt
 Kommentarer: Obligatorisk ved blanding av fysisk og elektronisk arkiv. Er hele arkivet
@@ -20,3 +19,4 @@ Kommentarer: Obligatorisk ved blanding av fysisk og elektronisk arkiv. Er hele a
   til *M208 referanseArkivdel.*
 Navn: dokumentmedium
 Nr: M300
+Utdatert: nei

--- a/metadata/M301.yaml
+++ b/metadata/M301.yaml
@@ -5,7 +5,6 @@ Datatype: Tekststreng
 Definisjon: Stedet hvor de fysiske dokumentene oppbevares. Kan være angivelse av rom,
   hylle, skap osv. Overordnede arkivdeler (f.eks. en arkivdel) kan oppbevares på flere
   steder.
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Arves fra overordnet nivå, kan overstyres manuelt
 Kommentarer: Fysiske dokumenters plassering skal ellers gå fram av arkivstrukturen.
@@ -16,3 +15,4 @@ Kommentarer: Fysiske dokumenters plassering skal ellers gå fram av arkivstruktu
   ("dokumentnummer"). Vedlegg skal legges sammen med tilhørende hoveddokument.
 Navn: oppbevaringssted
 Nr: M301
+Utdatert: nei

--- a/metadata/M302.yaml
+++ b/metadata/M302.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på virksomhet eller person som er part
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt eller automatisk fra fagsystem
 Kommentarer:
 Navn: partNavn
 Nr: M302
+Utdatert: nei

--- a/metadata/M303.yaml
+++ b/metadata/M303.yaml
@@ -9,9 +9,9 @@ Betingelser: |-
   - Advokat
 Datatype: Tekststreng
 Definisjon: Angivelse av rollen til parten
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt eller automatisk fra fagsystem
 Kommentarer:
 Navn: partRolle
 Nr: M303
+Utdatert: nei

--- a/metadata/M304.yaml
+++ b/metadata/M304.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall fysiske vedlegg til et fysisk hoveddokument
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt
 Kommentarer:
 Navn: antallVedlegg
 Nr: M304
+Utdatert: nei

--- a/metadata/M305.yaml
+++ b/metadata/M305.yaml
@@ -4,7 +4,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på avdeling, kontor eller annen administrativ enhet som har ansvaret
   for saksbehandlingen.
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres automatisk f.eks. på grunnlag av innlogget bruker, kan overstyres
 Kommentarer: Merk at på journalpostnivå grupperes *administrativEnhet* sammen med
@@ -13,3 +12,4 @@ Kommentarer: Merk at på journalpostnivå grupperes *administrativEnhet* sammen 
   som skal følges opp.
 Navn: administrativEnhet
 Nr: M305
+Utdatert: nei

--- a/metadata/M306.yaml
+++ b/metadata/M306.yaml
@@ -3,10 +3,10 @@ Arv: Ja til journalpost, jf. *M307 saksbehandler*
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som er saksansvarlig
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres automatisk på grunnlag av innlogget bruker eller annen saksbehandlingsfunksjonalitet
   (f.eks. saksfordeling), kan overstyres manuelt
 Kommentarer:
 Navn: saksansvarlig
 Nr: M306
+Utdatert: nei

--- a/metadata/M307.yaml
+++ b/metadata/M307.yaml
@@ -4,7 +4,6 @@ Arv: Ja fra saksmappe til journalpost, jf. *M306* *saksansvarlig.* Saksansvarlig
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som er saksbehandler
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres automatisk på grunnlag av innlogget bruker eller annen saksbehandlingsfunksjonalitet
   (f.eks. saksfordeling), kan overstyres manuelt.
@@ -12,3 +11,4 @@ Kommentarer: Merk at *saksbehandler* grupperes inn i korrespondansepart på jour
   Se kommentar til *M305 administrativEnhet*.
 Navn: saksbehandler
 Nr: M307
+Utdatert: nei

--- a/metadata/M308.yaml
+++ b/metadata/M308.yaml
@@ -7,9 +7,9 @@ Datatype: Tekststreng
 Definisjon: Navn på enhet som har det arkivmessige ansvaret for kvalitetssikring av
   arkivdanningen, og eventuelt registrering (journalføring) og arkivering av fysiske
   dokumenter
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres automatisk på grunnlag av innlogget bruker, kan overstyres manuelt
 Kommentarer:
 Navn: journalenhet
 Nr: M308
+Utdatert: nei

--- a/metadata/M309.yaml
+++ b/metadata/M309.yaml
@@ -4,9 +4,9 @@ Betingelser: Utlån skal også kunne registreres etter at en saksmappe er avslut
   eller at dokumentene i en journalpost ble arkivert
 Datatype: Tekststreng
 Definisjon: Navnet på person som har lånt en fysisk saksmappe
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt ved utlån
 Kommentarer:
 Navn: utlaantTil
 Nr: M309
+Utdatert: nei

--- a/metadata/M310.yaml
+++ b/metadata/M310.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Merknad fra saksbehandler, leder eller arkivpersonale.
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt
 Kommentarer: Merknaden bør gjelde selve saksbehandlingen eller forhold rundt arkiveringen
   av dokumentene som tilhører arkivenheten.
 Navn: merknadstekst
 Nr: M310
+Utdatert: nei

--- a/metadata/M311.yaml
+++ b/metadata/M311.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Lovparagrafen som saken eller journalposten danner presedens for
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt ved opprettelse av presedens
 Kommentarer:
 Navn: presedensHjemmel
 Nr: M311
+Utdatert: nei

--- a/metadata/M312.yaml
+++ b/metadata/M312.yaml
@@ -4,7 +4,6 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: En argumentkilde som brukes til å løse rettslige problemer. En retts­anvender
   som skal ta stilling til et juridisk spørsmål, vil ta utgangspunkt i en rettskildefaktor.
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde: Registreres manuelt ved opprettelse av presedens
 Kommentarer: En rettskildefaktor kan være en lov- eller forskriftstekst, lovforarbeider,
@@ -12,3 +11,4 @@ Kommentarer: En rettskildefaktor kan være en lov- eller forskriftstekst, lovfor
   rettsoppfatninger, reelle hensyn, folkerett, EU-/ EØS-rett mv.
 Navn: rettskildefaktor
 Nr: M312
+Utdatert: nei

--- a/metadata/M313.yaml
+++ b/metadata/M313.yaml
@@ -5,10 +5,10 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Beskrivelse av kriteriene som er brukt ved seleksjon av journalrapportenes
   innhold.
-Gjeldende: true
 Gruppe: Arkiv- og saksbehandlingsfunksjonalitet
 Kilde:
 Kommentarer: Både løpende og offentlig journal er i utgangspunktet selektert etter
   journaldato. Andre kriterier kan eventuelt brukes i tillegg.
 Navn: seleksjon
 Nr: M313
+Utdatert: nei

--- a/metadata/M370.yaml
+++ b/metadata/M370.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på utvalget som avholdt møte
-Gjeldende: true
 Gruppe: Møtebehandling
 Kilde: Registreres manuelt ved opprettelsen av møtemappen
 Kommentarer:
 Navn: utvalg
 Nr: M370
+Utdatert: nei

--- a/metadata/M371.yaml
+++ b/metadata/M371.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Sted hvor møtet ble avholdt
-Gjeldende: true
 Gruppe: Møtebehandling
 Kilde: Registreres manuelt ved opprettelsen av møtemappen
 Kommentarer:
 Navn: moetested
 Nr: M371
+Utdatert: nei

--- a/metadata/M372.yaml
+++ b/metadata/M372.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som var til stedet på møtet
-Gjeldende: true
 Gruppe: Møtebehandling
 Kilde: Registreres manuelt ved opprettelsen av møtemappen, kan eventuelt også hentes
   automatisk fra f.eks. møteinnkalling
 Kommentarer:
 Navn: moetedeltakerNavn
 Nr: M372
+Utdatert: nei

--- a/metadata/M373.yaml
+++ b/metadata/M373.yaml
@@ -7,9 +7,9 @@ Betingelser: |-
   - "Referent"
 Datatype: Tekststreng
 Definisjon: Funksjon eller rolle til personen som deltok på møtet
-Gjeldende: true
 Gruppe: Møtebehandling
 Kilde:
 Kommentarer:
 Navn: moetedeltakerFunksjon
 Nr: M373
+Utdatert: nei

--- a/metadata/M400.yaml
+++ b/metadata/M400.yaml
@@ -3,7 +3,6 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person eller organisasjon som er avsender eller mottaker av dokumentet
-Gjeldende: true
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer: Navn på korrespondansepart forekommer én gang innenfor objektet korrespondansepart,
@@ -11,3 +10,4 @@ Kommentarer: Navn på korrespondansepart forekommer én gang innenfor objektet k
   elementene nedenfor.
 Navn: korrespondansepartNavn
 Nr: M400
+Utdatert: nei

--- a/metadata/M406.yaml
+++ b/metadata/M406.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Postadressen til en avsender /mottaker eller part
-Gjeldende: true
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer: En postadresse kan angis som flere elementer ("adresselinjer"), noe som
   kan være aktuelt ved bestemte utenlandske adresser
 Navn: postadresse
 Nr: M406
+Utdatert: nei

--- a/metadata/M407.yaml
+++ b/metadata/M407.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Postnummeret til en avsender /mottaker eller part
-Gjeldende: true
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:
 Navn: postnummer
 Nr: M407
+Utdatert: nei

--- a/metadata/M408.yaml
+++ b/metadata/M408.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Poststedet til en avsender/mottaker eller part
-Gjeldende: true
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:
 Navn: poststed
 Nr: M408
+Utdatert: nei

--- a/metadata/M409.yaml
+++ b/metadata/M409.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Land dersom adressen er i utlandet
-Gjeldende: true
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:
 Navn: land
 Nr: M409
+Utdatert: nei

--- a/metadata/M410.yaml
+++ b/metadata/M410.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: E-postadressen til en avsender/mottaker eller part
-Gjeldende: true
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk fra dokumentet
 Kommentarer:
 Navn: epostadresse
 Nr: M410
+Utdatert: nei

--- a/metadata/M411.yaml
+++ b/metadata/M411.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Telefonnummeret til en avsender/mottaker eller part
-Gjeldende: true
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk
 Kommentarer:
 Navn: telefonnummer
 Nr: M411
+Utdatert: nei

--- a/metadata/M412.yaml
+++ b/metadata/M412.yaml
@@ -4,9 +4,9 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Kontaktperson hos en organisasjon som er avsender eller mottaker, eller
   part
-Gjeldende: true
 Gruppe: Korrespondanse
 Kilde: Registreres manuelt eller automatisk
 Kommentarer:
 Navn: kontaktperson
 Nr: M412
+Utdatert: nei

--- a/metadata/M450.yaml
+++ b/metadata/M450.yaml
@@ -8,10 +8,10 @@ Betingelser: |-
   - "Vurderes senere"
 Datatype: Tekststreng
 Definisjon: Handling som skal utføres ved bevaringstidens slutt.
-Gjeldende: true
 Gruppe: Bevaring og kassasjon
 Kilde: Registreres manuelt ved opprettelse av *arkivdel* eller *klasse*. Arves til
   underliggende enheter, men kan endres manuelt.
 Kommentarer:
 Navn: kassasjonsvedtak
 Nr: M450
+Utdatert: nei

--- a/metadata/M451.yaml
+++ b/metadata/M451.yaml
@@ -3,7 +3,6 @@ Arv: Ja
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall år dokumentene som tilhører denne arkivdelen skal bevares.
-Gjeldende: true
 Gruppe: Bevaring og kassasjon
 Kilde: Registreres manuelt ved opprettelse av *arkivdel* eller *klasse*. Arves til
   underliggende enheter, men kan endres manuelt.
@@ -11,3 +10,4 @@ Kommentarer: Tidspunktet for når bevaringstiden starter å løpe, vil vanligvis
   når en mappe avsluttes. Men andre regler kan være aktuelle.
 Navn: bevaringstid
 Nr: M451
+Utdatert: nei

--- a/metadata/M452.yaml
+++ b/metadata/M452.yaml
@@ -4,10 +4,10 @@ Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato for når dokumentene som tilhører denne arkivenheten skal kunne kasseres,
   eller vurderes for bevaring og kassasjon på ny
-Gjeldende: true
 Gruppe: Bevaring og kassasjon
 Kilde: Datoen beregnes automatisk på grunnlag av *M451 Bevaringstid*, eller registreres
   manuelt
 Kommentarer:
 Navn: kassasjonsdato
 Nr: M452
+Utdatert: nei

--- a/metadata/M453.yaml
+++ b/metadata/M453.yaml
@@ -3,10 +3,10 @@ Arv:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Angivelse av hjemmel for kassasjon
-Gjeldende: true
 Gruppe: Bevaring og kassasjon
 Kilde: Registreres manuelt ved opprettelse av *arkivdel* eller *klasse*. Arves til
   underliggende enheter, men kan endres manuelt
 Kommentarer: Hjemmel kan f.eks. være Riksarkivarens bevarings- og kassasjons­vedtak.
 Navn: kassasjonshjemmel
 Nr: M453
+Utdatert: nei

--- a/metadata/M500.yaml
+++ b/metadata/M500.yaml
@@ -12,9 +12,9 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av at dokumentene som tilhører arkivenheten ikke er offentlig
   tilgjengelig i henhold til offentlighetsloven eller av en annen grunn
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Registreres manuelt ved valg fra liste, kan også registres automatisk
 Kommentarer:
 Navn: tilgangsrestriksjon
 Nr: M500
+Utdatert: nei

--- a/metadata/M501.yaml
+++ b/metadata/M501.yaml
@@ -4,9 +4,9 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Henvisning til hjemmel (paragraf) i offentlighetsloven, sikkerhetsloven
   eller beskyttelsesinstruksen
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Registreres automatisk på grunnlag av valgt tilgangskode, kan overstyres manuelt
 Kommentarer:
 Navn: skjermingshjemmel
 Nr: M501
+Utdatert: nei

--- a/metadata/M502.yaml
+++ b/metadata/M502.yaml
@@ -17,7 +17,6 @@ Betingelser: |-
   - "Midlertidig skjerming"
 Datatype: Tekststreng
 Definisjon: Angivelse av hvilke metadataelementer som skal skjermes.
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Registreres manuelt ved valg fra liste eller annen funksjonalitet, kan også
   registreres automatisk
@@ -30,3 +29,4 @@ Kommentarer: Skjerming av klasseID (arkivnøkkel, arkivkode) er f.eks. aktuelt n
   skjermingsbehovet er vurdert.
 Navn: skjermingMetadata
 Nr: M502
+Utdatert: nei

--- a/metadata/M503.yaml
+++ b/metadata/M503.yaml
@@ -7,7 +7,6 @@ Betingelser: |-
   - "Skjerming av deler av dokumentet"
 Datatype: Tekststreng
 Definisjon: Angivelse av at hele dokumentet eller deler av det må skjermes.
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Registreres manuelt ved valg fra liste eller annen funksjonalitet, kan også
   registreres automatisk
@@ -15,3 +14,4 @@ Kommentarer: Dersom deler av dokumentet skal skjermes, må dokumentet også finn
   en variant. Her må all informasjon som skal skjermes, være "sladdet".
 Navn: skjermingDokument
 Nr: M503
+Utdatert: nei

--- a/metadata/M504.yaml
+++ b/metadata/M504.yaml
@@ -3,10 +3,10 @@ Arv: Ja
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall år skjermingen skal opprettholdes.
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Registreres automatisk knyttet til valg av tilgangskode, kan registreres manuelt.
 Kommentarer: Tidspunktet for når skjermingsvarigheten starter å løpe, vil vanligvis
   være når journalposten ble registrert, men det skal være mulig med andre regler.
 Navn: skjermingsvarighet
 Nr: M504
+Utdatert: nei

--- a/metadata/M505.yaml
+++ b/metadata/M505.yaml
@@ -3,9 +3,9 @@ Arv: Ja
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Datoen skjermingen skal oppheves.
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Datoen beregnes automatisk på grunnlag av *M504 skjermingsvarighet*
 Kommentarer:
 Navn: skjermingOpphoererDato
 Nr: M505
+Utdatert: nei

--- a/metadata/M506.yaml
+++ b/metadata/M506.yaml
@@ -14,7 +14,6 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av at dokumentene er gradert i henhold til sikkerhetsloven eller
   beskyttelsesinstruksen.
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Registreres manuelt ved valg fra liste, kan også registres automatisk
 Kommentarer: Dokumenter gradert "Strengt hemmelig", "Hemmelig", "Konfidensielt" og
@@ -22,3 +21,4 @@ Kommentarer: Dokumenter gradert "Strengt hemmelig", "Hemmelig", "Konfidensielt" 
   innsyn.
 Navn: graderingskode
 Nr: M506
+Utdatert: nei

--- a/metadata/M507.yaml
+++ b/metadata/M507.yaml
@@ -10,9 +10,9 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av hvilket sikkerhetsnivå som ble brukt ved forsendelse og mottak
   av elektroniske dokumenter
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Registreres automatisk knyttet til funksjonalitet for elektronisk signatur
 Kommentarer:
 Navn: elektroniskSignaturSikkerhetsnivaa
 Nr: M507
+Utdatert: nei

--- a/metadata/M508.yaml
+++ b/metadata/M508.yaml
@@ -8,10 +8,10 @@ Betingelser: |-
 Datatype: Tekststreng
 Definisjon: Angivelse av om et dokument er mottatt med elektronisk signatur, og om
   signaturen er verifisert.
-Gjeldende: true
 Gruppe: Skjerming og gradering
 Kilde: Registreres automatisk knyttet til funksjonalitet for elektronisk signatur
 Kommentarer: Dersom signaturen er verifisert, skal det logges hvem som verifiserte
   den og når det skjedde
 Navn: elektroniskSignaturVerifisert
 Nr: M508
+Utdatert: nei

--- a/metadata/M580.yaml
+++ b/metadata/M580.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på bruker av en Noark 5-løsning
-Gjeldende: true
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer: Navn på bruker vil registreres mange steder i arkivstrukturen, f.eks.
   som saksansvarlig eller saksbehandler, og ved forskjellige typer logging.
 Navn: brukerNavn
 Nr: M580
+Utdatert: nei

--- a/metadata/M581.yaml
+++ b/metadata/M581.yaml
@@ -9,9 +9,9 @@ Betingelser: |-
   - "Saksbehandler"
 Datatype: Tekststreng
 Definisjon: Rollen til en bruker av en Noark 5-løsning.
-Gjeldende: true
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer:
 Navn: brukerRolle
 Nr: M581
+Utdatert: nei

--- a/metadata/M582.yaml
+++ b/metadata/M582.yaml
@@ -7,9 +7,9 @@ Betingelser: |-
   - "Sluttet"
 Datatype: Tekststreng
 Definisjon: Status til en bruker av en Noark 5-løsning.
-Gjeldende: true
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer:
 Navn: brukerstatus
 Nr: M582
+Utdatert: nei

--- a/metadata/M583.yaml
+++ b/metadata/M583.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på administrativ enhet
-Gjeldende: true
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer: Navn på administrativ enhet vil registreres flere steder i arkivstrukturen,
   f.eks. sammen med saksansvarlig eller saksbehandler på saksmappe eller journalpost.
 Navn: administrativEnhetNavn
 Nr: M583
+Utdatert: nei

--- a/metadata/M584.yaml
+++ b/metadata/M584.yaml
@@ -7,9 +7,9 @@ Betingelser: |-
   - "Passiv enhet"
 Datatype: Tekststreng
 Definisjon: Status til den administrative enheten
-Gjeldende: true
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer:
 Navn: administrativEnhetsstatus
 Nr: M584
+Utdatert: nei

--- a/metadata/M585.yaml
+++ b/metadata/M585.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til enhet som er direkte overordnet denne enheten
-Gjeldende: true
 Gruppe: Brukeradministrasjon og administrasjonsstruktur
 Kilde: Registreres manuelt av administrator
 Kommentarer:
 Navn: referanseOverordnetEnhet
 Nr: M585
+Utdatert: nei

--- a/metadata/M600.yaml
+++ b/metadata/M600.yaml
@@ -4,9 +4,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten ble opprettet/registrert
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: opprettetDato
 Nr: M600
+Utdatert: nei

--- a/metadata/M601.yaml
+++ b/metadata/M601.yaml
@@ -4,9 +4,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Navn på person som opprettet/registrerte arkivenheten
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: opprettetAv
 Nr: M601
+Utdatert: nei

--- a/metadata/M602.yaml
+++ b/metadata/M602.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivdelen er avsluttet.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten ble avsluttet/lukket
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet når enheten avsluttes
 Kommentarer:
 Navn: avsluttetDato
 Nr: M602
+Utdatert: nei

--- a/metadata/M603.yaml
+++ b/metadata/M603.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivenheten er avsluttet.
 Datatype: Tekststreng
 Definisjon: Navn på person som avsluttet/lukket arkivenheten
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet ved opprettelse av enheten
 Kommentarer:
 Navn: avsluttetAv
 Nr: M603
+Utdatert: nei

--- a/metadata/M604.yaml
+++ b/metadata/M604.yaml
@@ -4,7 +4,6 @@ Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når alle dokumentene som er tilknyttet registreringen
   ble arkivert
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved utførelse av en funksjon som markerer at dokumentene
   er arkivert. For journalposter kan dette knyttes til endring av journalstatus.
@@ -12,3 +11,4 @@ Kommentarer: Arkivering innebærer at dokumentene blir "frosset", dvs. sperret f
   all videre redigering/endring
 Navn: arkivertDato
 Nr: M604
+Utdatert: nei

--- a/metadata/M605.yaml
+++ b/metadata/M605.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som arkiverte dokumentet og frøs det for all videre redigering
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved utførelse av en funksjon som markerer at dokumentene
   er arkivert. For journalposter kan dette knyttes til endring av journalstatus.
 Kommentarer:
 Navn: arkivertAv
 Nr: M605
+Utdatert: nei

--- a/metadata/M606.yaml
+++ b/metadata/M606.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har foretatt (eller er ansvarlig for) eksport av metadata og dokumenter
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres manuelt eller automatisk ved produksjon av avleveringsuttrekk
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Informasjonen skal både inngå i uttrekket og lagres i systemet
 Navn: ansvarligEksport
 Nr: M606
+Utdatert: nei

--- a/metadata/M607.yaml
+++ b/metadata/M607.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når eksporten skjedde
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved produksjon av avleveringsuttrekk
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Informasjonen skal både inngå i uttrekket og lagres i systemet.
 Navn: eksportertDato
 Nr: M607
+Utdatert: nei

--- a/metadata/M608.yaml
+++ b/metadata/M608.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Antall mapper som inngikk i eksporten
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved produksjon av avleveringsuttrekk
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Informasjonen skal både inngå i uttrekket og lagres i systemet.
 Navn: antallMapperEksportert
 Nr: M608
+Utdatert: nei

--- a/metadata/M609.yaml
+++ b/metadata/M609.yaml
@@ -4,9 +4,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Heltall
 Definisjon: Antall journalposter i rapporten
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved produksjon av avleveringsuttrekk
 Kommentarer:
 Navn: antallJournalposter
 Nr: M609
+Utdatert: nei

--- a/metadata/M610.yaml
+++ b/metadata/M610.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Obligatorisk ved avlevering dersom eksporten omfatter elektroniske dokumenter. Kan ikke endres
 Datatype: Heltall
 Definisjon: Antall elektroniske dokumenter (dokumentfiler) som inngikk i eksporten
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved produksjon av avleveringsuttrekk
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: antallDokumenterEksportert
 Nr: M610
+Utdatert: nei

--- a/metadata/M611.yaml
+++ b/metadata/M611.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når merknaden ble registrert
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet
 Kommentarer:
 Navn: merknadsdato
 Nr: M611
+Utdatert: nei

--- a/metadata/M612.yaml
+++ b/metadata/M612.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har registrert merknaden
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet
 Kommentarer:
 Navn: merknadRegistrertAv
 Nr: M612
+Utdatert: nei

--- a/metadata/M613.yaml
+++ b/metadata/M613.yaml
@@ -3,7 +3,6 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble slettet
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når en tidligere versjon eller en variant av et dokument
   slettes.
@@ -11,3 +10,4 @@ Kommentarer: Informasjon om sletting av dokumenter i produksjonsformat skal ikke
   Sletting må ikke blandes sammen med kassasjon.
 Navn: slettetDato
 Nr: M613
+Utdatert: nei

--- a/metadata/M614.yaml
+++ b/metadata/M614.yaml
@@ -4,9 +4,9 @@ Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har utført en kontrollert kassasjon av dokumenter,
   eller sletting av versjoner, formater og varianter.
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når et dokument blir slettet
 Kommentarer: Sletting må ikke blandes sammen med kassasjon.
 Navn: slettetAv
 Nr: M614
+Utdatert: nei

--- a/metadata/M615.yaml
+++ b/metadata/M615.yaml
@@ -4,9 +4,9 @@ Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett for når et dokument ble konvertert fra et format til
   et annet
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved konvertering
 Kommentarer:
 Navn: konvertertDato
 Nr: M615
+Utdatert: nei

--- a/metadata/M616.yaml
+++ b/metadata/M616.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Person eller system som har foretatt konverteringen
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved konvertering
 Kommentarer:
 Navn: konvertertAv
 Nr: M616
+Utdatert: nei

--- a/metadata/M617.yaml
+++ b/metadata/M617.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato et dokument ble avskrevet
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk nå avskrivning foretas
 Kommentarer:
 Navn: avskrivningsdato
 Nr: M617
+Utdatert: nei

--- a/metadata/M618.yaml
+++ b/metadata/M618.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har foretatt avskrivning
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når avskrivning foretas
 Kommentarer:
 Navn: avskrevetAv
 Nr: M618
+Utdatert: nei

--- a/metadata/M619.yaml
+++ b/metadata/M619.yaml
@@ -10,9 +10,9 @@ Betingelser: |-
   - "Tatt til orientering"
 Datatype: Tekststreng
 Definisjon: Måten en journalpost har blitt avskrevet på
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når konvertering utføres.
 Kommentarer:
 Navn: avskrivningsmaate
 Nr: M619
+Utdatert: nei

--- a/metadata/M620.yaml
+++ b/metadata/M620.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Datoen et dokument ble knyttet til en registrering
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk nå tilknytning foretas
 Kommentarer:
 Navn: tilknyttetDato
 Nr: M620
+Utdatert: nei

--- a/metadata/M621.yaml
+++ b/metadata/M621.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som knyttet et dokument til en registrering
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når tilknytning foretas
 Kommentarer:
 Navn: tilknyttetAv
 Nr: M621
+Utdatert: nei

--- a/metadata/M622.yaml
+++ b/metadata/M622.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato en elektronisk signatur ble verifisert
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når verifisering utføres
 Kommentarer:
 Navn: verifisertDato
 Nr: M622
+Utdatert: nei

--- a/metadata/M623.yaml
+++ b/metadata/M623.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har verifisert en elektronisk signatur
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når verifisering utføres
 Kommentarer:
 Navn: verifisertAv
 Nr: M623
+Utdatert: nei

--- a/metadata/M624.yaml
+++ b/metadata/M624.yaml
@@ -3,9 +3,9 @@ Arv: Ja
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble gradert
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved gradering
 Kommentarer:
 Navn: graderingsdato
 Nr: M624
+Utdatert: nei

--- a/metadata/M625.yaml
+++ b/metadata/M625.yaml
@@ -3,9 +3,9 @@ Arv: Ja
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som foretok graderingen
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved gradering
 Kommentarer:
 Navn: gradertAv
 Nr: M625
+Utdatert: nei

--- a/metadata/M626.yaml
+++ b/metadata/M626.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble nedgradert
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved nedgradering
 Kommentarer:
 Navn: nedgraderingsdato
 Nr: M626
+Utdatert: nei

--- a/metadata/M627.yaml
+++ b/metadata/M627.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som foretok nedgraderingen
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk ved nedgradering
 Kommentarer:
 Navn: nedgradertAv
 Nr: M627
+Utdatert: nei

--- a/metadata/M628.yaml
+++ b/metadata/M628.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett for når presedensen er godkjent
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk dersom det finnes funksjonalitet for å godkjenne presedenser
 Kommentarer:
 Navn: presedensGodkjentDato
 Nr: M628
+Utdatert: nei

--- a/metadata/M629.yaml
+++ b/metadata/M629.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som har godkjent presedensen
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk dersom det finnes funksjonalitet for å godkjenne presedenser
 Kommentarer:
 Navn: presedensGodkjentAv
 Nr: M629
+Utdatert: nei

--- a/metadata/M630.yaml
+++ b/metadata/M630.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når kassasjonen ble utført
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når kassasjon utføres
 Kommentarer:
 Navn: kassertDato
 Nr: M630
+Utdatert: nei

--- a/metadata/M631.yaml
+++ b/metadata/M631.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har utført kassasjonen
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk når kassasjon utføres
 Kommentarer:
 Navn: kassertAv
 Nr: M631
+Utdatert: nei

--- a/metadata/M632.yaml
+++ b/metadata/M632.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten sist ble oppdatert
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet når oppdatering gjøres
 Kommentarer: NB! Ikke i bruk, slått sammen med M682 endretDato
 Navn: oppdatertDato
 Nr: M632
+Utdatert: nei

--- a/metadata/M633.yaml
+++ b/metadata/M633.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres.
 Datatype: Tekststreng
 Definisjon: Dato og klokkeslett når arkivenheten sist ble oppdatert
-Gjeldende: true
 Gruppe: Logging av hendelser
 Kilde: Registreres automatisk av systemet når oppdatering gjøres
 Kommentarer: NB! Ikke i bruk, slått sammen med M683 endretAv
 Navn: oppdatertAv
 Nr: M633
+Utdatert: nei

--- a/metadata/M660.yaml
+++ b/metadata/M660.yaml
@@ -5,9 +5,9 @@ Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke 
 Datatype: Tekststreng
 Definisjon: Person som har mottatt for godkjennelse et dokument som har vært sendt
   på flyt
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytTil
 Nr: M660
+Utdatert: nei

--- a/metadata/M661.yaml
+++ b/metadata/M661.yaml
@@ -4,9 +4,9 @@ Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke 
   endres.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett et dokument på flyt ble mottatt
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytMottattDato
 Nr: M661
+Utdatert: nei

--- a/metadata/M662.yaml
+++ b/metadata/M662.yaml
@@ -4,9 +4,9 @@ Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke 
   endres.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett et dokument på flyt ble sendt videre
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytSendtDato
 Nr: M662
+Utdatert: nei

--- a/metadata/M663.yaml
+++ b/metadata/M663.yaml
@@ -8,9 +8,9 @@ Betingelser: |-
   - "Sendt tilbake til saksbehandler med kommentarer"
 Datatype: Tekststreng
 Definisjon: Godkjennelse/ikke godkjennelse av dokumentet som er sendt på flyt
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytStatus
 Nr: M663
+Utdatert: nei

--- a/metadata/M664.yaml
+++ b/metadata/M664.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Merknad eller kommentar til et dokument som er sendt på flyt
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres manuelt
 Kommentarer:
 Navn: flytMerknad
 Nr: M664
+Utdatert: nei

--- a/metadata/M665.yaml
+++ b/metadata/M665.yaml
@@ -4,9 +4,9 @@ Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke 
   endres.
 Datatype: Tekststreng
 Definisjon: Person som har sendt et dokument på flyt
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til arbeidsflyt
 Kommentarer:
 Navn: flytFra
 Nr: M665
+Utdatert: nei

--- a/metadata/M666.yaml
+++ b/metadata/M666.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Person som har fått fordelt en saksmappe eller journalpost til saksbehandling
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til fordeling
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: fordeltTil
 Nr: M666
+Utdatert: nei

--- a/metadata/M667.yaml
+++ b/metadata/M667.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Person som har fordelt en saksmappe eller journalpost til saksbehandling
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til fordeling
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: fordeltAv
 Nr: M667
+Utdatert: nei

--- a/metadata/M668.yaml
+++ b/metadata/M668.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Dato da en saksmappe eller journalpost ble fordelt til saksbehandling
-Gjeldende: true
 Gruppe: Logging av arbeidsflyt og saksfordeling
 Kilde: Registreres automatisk av funksjonalitet knyttet til fordeling
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: fordeltDato
 Nr: M668
+Utdatert: nei

--- a/metadata/M680.yaml
+++ b/metadata/M680.yaml
@@ -4,9 +4,9 @@ Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til arkivenheten (systemID) som inneholder metadata­elementet
   som ble endret
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: referanseArkivenhet
 Nr: M680
+Utdatert: nei

--- a/metadata/M681.yaml
+++ b/metadata/M681.yaml
@@ -3,9 +3,9 @@ Arv:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navnet på metadataelementet som ble endret
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: referanseMetadata
 Nr: M681
+Utdatert: nei

--- a/metadata/M682.yaml
+++ b/metadata/M682.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten ble oppdatert eller et metadataelement sist ble endret
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved oppdatering av en arkivenhet eller endring av metadata
 Kommentarer: Erstatter M632 oppdatertDato
 Navn: endretDato
 Nr: M682
+Utdatert: nei

--- a/metadata/M683.yaml
+++ b/metadata/M683.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Navn på person som oppdaterte en arkivenhet eller endret metadata
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved oppdatering av en arkivenhet eller endring av metadata
 Kommentarer: Erstatter M633 oppdatertAv
 Navn: endretAv
 Nr: M683
+Utdatert: nei

--- a/metadata/M684.yaml
+++ b/metadata/M684.yaml
@@ -3,9 +3,9 @@ Arv:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Innholdet i metadataelementet før det ble endret
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: tidligereVerdi
 Nr: M684
+Utdatert: nei

--- a/metadata/M685.yaml
+++ b/metadata/M685.yaml
@@ -3,9 +3,9 @@ Arv:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Det nye innholdet i metadataelementet
-Gjeldende: true
 Gruppe: Logging av endringer
 Kilde: Registreres automatisk ved endring av metadata
 Kommentarer:
 Navn: nyVerdi
 Nr: M685
+Utdatert: nei

--- a/metadata/M700.yaml
+++ b/metadata/M700.yaml
@@ -10,9 +10,9 @@ Betingelser: |-
   Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Angivelse av hvilken variant et dokument forekommer i
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk når dokumentet arkiveres
 Kommentarer:
 Navn: variantformat
 Nr: M700
+Utdatert: nei

--- a/metadata/M701.yaml
+++ b/metadata/M701.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Dokumentets format
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk når dokumentet arkiveres
 Kommentarer:  Verdier hentes fra PRONOM og Arkivverket, nærmere
  beskrevet i del 2.7, Dokumentbeskrivelse og dokumentobjekt.
 Navn: format
 Nr: M701
+Utdatert: nei

--- a/metadata/M702.yaml
+++ b/metadata/M702.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Nærmere spesifikasjon av dokuments format, f.eks. informasjon om komprimering
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde:
 Kommentarer:
 Navn: formatDetaljer
 Nr: M702
+Utdatert: nei

--- a/metadata/M703.yaml
+++ b/metadata/M703.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Dokumentets format før det ble konvertert
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk ved konvertering
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1. Dette vil vanligvis være produksjonsformatet
 Navn: tidligereFormat
 Nr: M703
+Utdatert: nei

--- a/metadata/M704.yaml
+++ b/metadata/M704.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Nærmere spesifikasjon av dokuments format før det ble konvertert, f.eks. informasjon om komprimering
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk ved konvertering
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: tidligereFormatDetaljer 
 Nr: M704
+Utdatert: nei

--- a/metadata/M705.yaml
+++ b/metadata/M705.yaml
@@ -4,9 +4,9 @@ Betingelser: Kan ikke endres. Sjekksummen skal være heksadesimal uten noen form
 Datatype: Tekststreng
 Definisjon: En verdi som beregnes ut fra innholdet i dokumentet, og som dermed gir
   integritetssikring til dokumentets innhold
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Påføres automatisk i forbindelse med eksport for avlevering
 Kommentarer:
 Navn: sjekksum
 Nr: M705
+Utdatert: nei

--- a/metadata/M706.yaml
+++ b/metadata/M706.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres. Algoritmen som skal brukes inntil videre er SHA256.
 Datatype: Tekststreng
 Definisjon: Algoritmen som er brukt for å beregne sjekksummen
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk i forbindelse med eksport for avlevering
 Kommentarer:
 Navn: sjekksumAlgoritme
 Nr: M706
+Utdatert: nei

--- a/metadata/M707.yaml
+++ b/metadata/M707.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Heltall
 Definisjon: Størrelsen på fila i antall bytes.
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk i forbindelse med eksport for avlevering
 Kommentarer:
 Navn: filstoerrelse
 Nr: M707
+Utdatert: nei

--- a/metadata/M708.yaml
+++ b/metadata/M708.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: En verdi som beregnes ut fra innholdet i metadataobjektene i avleveringspakken, og som dermed gir integritessikring til metadataenes innhold
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Påføres automatisk i forbindelse med eksport for avlevering  
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: sjekksumMetadata
 Nr: M708
+Utdatert: nei

--- a/metadata/M709.yaml
+++ b/metadata/M709.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: En verdi som beregnes ut fra innholdet i hele avleveringspakken (både metadata- og dokumentobjekter), og som dermed gir integritetssikring til hele  avleveringspakken
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Påføres automatisk i forbindelse med eksport for avlevering  
 Kommentarer: NB! Gyldig t.o.m. versjon 2.1
 Navn: sjekksumAvlevering
 Nr: M709
+Utdatert: nei

--- a/metadata/M711.yaml
+++ b/metadata/M711.yaml
@@ -4,9 +4,9 @@ Betingelser:
 Datatype: Vilkårlig struktur
 Definisjon: Et overordnet metadataelement som kan inneholde egendefinerte metadata.
   Disse metadataene må da være spesifisert i et eller flere XML-skjema.
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde:
 Kommentarer:
 Navn: virksomhetsspesifikkeMetadata
 Nr: M711
+Utdatert: nei

--- a/metadata/M712.yaml
+++ b/metadata/M712.yaml
@@ -3,10 +3,10 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Formatet dokumentet hadde før det ble konvertert
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk ved konvertering
 Kommentarer: Dette vil vanligvis være produksjonsformatet, men kan
   også være et annet arkivformat. Bruker samme verdier som M701 format.
 Navn: konvertertFraFormat
 Nr: M712
+Utdatert: nei

--- a/metadata/M713.yaml
+++ b/metadata/M713.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Formatet dokumentet fikk etter konvertering
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk ved konvertering
 Kommentarer: Bruker samme verdier som M701 format.
 Navn: konvertertTilFormat
 Nr: M713
+Utdatert: nei

--- a/metadata/M714.yaml
+++ b/metadata/M714.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på det IT-verktøyet som ble brukt til å foreta konverteringen
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde:
 Kommentarer:
 Navn: konverteringsverktoey
 Nr: M714
+Utdatert: nei

--- a/metadata/M715.yaml
+++ b/metadata/M715.yaml
@@ -3,9 +3,9 @@ Arv: Nei
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Kommentarer til konverteringen
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde:
 Kommentarer:
 Navn: konverteringskommentar
 Nr: M715
+Utdatert: nei

--- a/metadata/M716.yaml
+++ b/metadata/M716.yaml
@@ -3,7 +3,6 @@ Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Dokumentets MIME-type
-Gjeldende: true
 Gruppe: Tekniske metadata
 Kilde: Registreres automatisk når et dokument overføres til arkivet
   eller settes av arkivklient.
@@ -14,3 +13,4 @@ Kommentarer: MIME-type for bruk når fil overføres via for eksempel
  MIME-typer og en MIME-type kan være koblet til flere PRONOM-koder.
 Navn: mimeType
 Nr: M716
+Utdatert: nei

--- a/scripts/metadata2rst
+++ b/scripts/metadata2rst
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
+from datetime import date
 import re
 import sys
 import yaml
@@ -24,7 +25,8 @@ def main():
     for filename in args.yamlfile:
         with open(filename, 'r') as f:
             info = yaml.load(f)
-            if 'Gjeldende' in info and not info['Gjeldende']:
+            if 'Utdatert' in info and 'nei' != info['Utdatert'] \
+               and date.fromisoformat(info['Utdatert']) < date.today():
                 continue
             for field in required:
                 if not field in info:

--- a/scripts/metadatarst2yaml
+++ b/scripts/metadatarst2yaml
@@ -66,7 +66,7 @@ class MetadataRstVisitor(docutils.nodes.NodeVisitor):
     def depart_table(self, node: docutils.nodes.Node) -> None:
         """Called when leaving a table."""
         #print(self.entry)
-        self.entry['Gjeldende'] = True
+        self.entry['Utdatert'] = 'nei'
 
         if self.entry['Nr'] in self.metadata:
             for field in ('Datatype'):


### PR DESCRIPTION
Feltet er 'nei' for metadataoppføringer som skal være med i
spesifikasjonsteksten, og har dato for når oppføringen ble utdatert
for de som ikke lenger skal være med.

Basert på forslag i #95.