### PR TITLE
Fjernet avleveringsinformasjon fra YAML-filer

### DIFF
--- a/metadata/M001.yaml
+++ b/metadata/M001.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse,
   dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Regex: "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"

--- a/metadata/M002.yaml
+++ b/metadata/M002.yaml
@@ -2,7 +2,6 @@ Arkivenhet: klasse
 Arv: I hierarkiske klassifikasjonssystemer (f.eks. statens arkivnøkkel) skal en underordnet
   klasse arve og aggregere (slå sammen) identifikasjonen fra alle overordnede klasser,
   se kommentar nedenfor.
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av klassen innenfor klassifikasjonssystemet.

--- a/metadata/M003.yaml
+++ b/metadata/M003.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: mappe
 Arv: Ja, til registrering, og aggregeres i *M004* *registreringsID* i kombinasjon
   med *M015 journalpostnummer*
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av mappen innenfor det arkivet mappen tilhører.

--- a/metadata/M004.yaml
+++ b/metadata/M004.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: registrering
 Arv: Kan arve *M003 mappeID* fra mappe og kombinere det med *M015 journalpostnummer*
-Avleveres: A
 Betingelser: Skal normalt ikke kunne endres. Ved flytting til en annen mappe, kan
   endring av *registreringsID* forekomme.
 Datatype: Tekststreng

--- a/metadata/M005.yaml
+++ b/metadata/M005.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke endres. Den eldste versjonen skal ha det laveste nummeret.
   Dersom arkiverte versjoner er slettet (gjelder ikke siste versjon), vil dette skape
   "huller" i nummerrekkefølgen.

--- a/metadata/M006.yaml
+++ b/metadata/M006.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Unik ID for arkivskaperen

--- a/metadata/M007.yaml
+++ b/metadata/M007.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Identifikasjon av dokumentene innenfor en registrering

--- a/metadata/M008.yaml
+++ b/metadata/M008.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moetemappe
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Identifikasjon av møter som et utvalg har avholdt, viser rekkefølgene

--- a/metadata/M009.yaml
+++ b/metadata/M009.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: 
 Datatype: Tekststreng
 Definisjon: Rekkefølgenummer for  journalposter

--- a/metadata/M010.yaml
+++ b/metadata/M010.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: part
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Unik ID for en part

--- a/metadata/M011.yaml
+++ b/metadata/M011.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe
 Arv: Kopieres fra *M003 mappeID*
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Inngår i *M003 mappeID*. Viser året saksmappen ble opprettet.

--- a/metadata/M012.yaml
+++ b/metadata/M012.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe
 Arv: Kopieres fra *M003 mappeID*
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Inngår i *M003 mappeID*. Viser rekkefølgen når saksmappen ble opprettet

--- a/metadata/M013.yaml
+++ b/metadata/M013.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv:
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Viser året journalposten ble opprettet

--- a/metadata/M014.yaml
+++ b/metadata/M014.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv:
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Heltall
 Definisjon: Viser rekkefølgen når journalposten ble opprettet under året

--- a/metadata/M015.yaml
+++ b/metadata/M015.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv:
-Avleveres: A
 Betingelser: Skal normalt ikke endres, men ved flytting til en annen saksmappe kan
   journalposten få et nytt nummer (fordi det inngår i en annen nummerrekkefølge i
   denne mappen).

--- a/metadata/M020.yaml
+++ b/metadata/M020.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse
   (ikke dokumentobjekt), forekommer også i presedens
 Arv: Kan eventuelt arves fra *klasse*, se ovenfor
-Avleveres: A
 Betingelser: Skal normalt ikke kunne endres etter at enheten er lukket, eller dokumentene
   arkivert
 Datatype: Tekststreng

--- a/metadata/M021.yaml
+++ b/metadata/M021.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse
   (ikke dokumentobjekt), forekommer også i arkivskaper og presedens
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Tekstlig beskrivelse av arkivenheten

--- a/metadata/M022.yaml
+++ b/metadata/M022.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: klasse, mappe, registrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Nøkkeord eller stikkord som beskriver innholdet i enheten

--- a/metadata/M023.yaml
+++ b/metadata/M023.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på organisasjonen som har skapt arkivet

--- a/metadata/M024.yaml
+++ b/metadata/M024.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person (eller eventuelt organisasjon) som har forfattet eller

--- a/metadata/M025.yaml
+++ b/metadata/M025.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering
 Arv:
-Avleveres: A
 Betingelser: Obligatorisk i arkivuttrekk dersom tittelen inneholder ord som skal skjermes,
   jf. *M504 skjermingMetadata.*
 Datatype: Tekststreng

--- a/metadata/M030.yaml
+++ b/metadata/M030.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: matrikkelnummer, planident
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Firesifret kode som entydig identifiserer en kommune

--- a/metadata/M031.yaml
+++ b/metadata/M031.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: matrikkelnummer
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Nummerering av gårdsenhet i matrikkelen, nummeret er unikt innenfor kommunen

--- a/metadata/M032.yaml
+++ b/metadata/M032.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: matrikkelnummer
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Fortløpende nummerering av bruk under gårdsnummer

--- a/metadata/M033.yaml
+++ b/metadata/M033.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: matrikkelnummer
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Fortløpende nummerering av fester under gårdsnummer/bruksnummer

--- a/metadata/M034.yaml
+++ b/metadata/M034.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: matrikkelnummer
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Fortløpende nummerering av seksjoner under gårdsnummer/bruksnummer og eventuelt festenummer

--- a/metadata/M035.yaml
+++ b/metadata/M035.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: byggident
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Entydig identifikasjon av bygning i matrikkelen

--- a/metadata/M036.yaml
+++ b/metadata/M036.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: byggident
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Entydig identifikasjon av endring av bygning i matrikkelen

--- a/metadata/M037.yaml
+++ b/metadata/M037.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: planident
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: To-sifret kode som entydig identifiserer et fylke

--- a/metadata/M038.yaml
+++ b/metadata/M038.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: part, korrespondansepart, planident
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av et land

--- a/metadata/M039.yaml
+++ b/metadata/M039.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: planident
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon for en plan innen en kommune eller et fylke

--- a/metadata/M040.yaml
+++ b/metadata/M040.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: posisjon
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Østlig koordinat for et geografisk punkt

--- a/metadata/M041.yaml
+++ b/metadata/M041.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: posisjon
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Nordlig koordinat for et geografisk punkt

--- a/metadata/M042.yaml
+++ b/metadata/M042.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: posisjon
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Høyden til et geografisk punkt

--- a/metadata/M043.yaml
+++ b/metadata/M043.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: posisjon
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Geografiske koordinaters referansesystem

--- a/metadata/M048.yaml
+++ b/metadata/M048.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: part, korrespondansepart
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av en person

--- a/metadata/M049.yaml
+++ b/metadata/M049.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: part, korrespondansepart
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Entydig identifikasjon av en organisasjon

--- a/metadata/M050.yaml
+++ b/metadata/M050.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M051.yaml
+++ b/metadata/M051.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M052.yaml
+++ b/metadata/M052.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M053.yaml
+++ b/metadata/M053.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M054.yaml
+++ b/metadata/M054.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M055.yaml
+++ b/metadata/M055.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moeteregistrering
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Valgfrie verdier, eksempler:
 

--- a/metadata/M056.yaml
+++ b/metadata/M056.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe eller journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M082.yaml
+++ b/metadata/M082.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M083.yaml
+++ b/metadata/M083.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Ingen obligatoriske typer. Aktuelle verdier kan f.eks. være:
 

--- a/metadata/M084.yaml
+++ b/metadata/M084.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering og dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Ingen obligatoriske typer. Aktuelle verdier kan f.eks. være:
 

--- a/metadata/M085.yaml
+++ b/metadata/M085.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moeteregistrering
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Ingen obligatoriske typer. Aktuelle verdier kan f.eks. være:
 

--- a/metadata/M086.yaml
+++ b/metadata/M086.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: klassifikasjonssystem
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Ingen obligatoriske typer. Aktuelle verdier kan f.eks. være:
 

--- a/metadata/M087.yaml
+++ b/metadata/M087.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: registrering
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M088.yaml
+++ b/metadata/M088.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moeteregistrering
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Foreslåtte verdier:
 

--- a/metadata/M089.yaml
+++ b/metadata/M089.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M100.yaml
+++ b/metadata/M100.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe
 Arv: Nei
-Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil saksmappen avsluttes
 Datatype: Dato og klokkeslett
 Definisjon: Datoen saken er opprettet

--- a/metadata/M101.yaml
+++ b/metadata/M101.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil arkivering
 Datatype: Dato og klokkeslett
 Definisjon: Datoen journalposten er journalført

--- a/metadata/M102.yaml
+++ b/metadata/M102.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moetemappe
 Arv: Nei
-Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil mappen avsluttes.
 Datatype: Dato og klokkeslett
 Definisjon: Datoen når et utvalgsmøte blir avholdt

--- a/metadata/M103.yaml
+++ b/metadata/M103.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: Skal kunne endres manuelt inntil arkivering
 Datatype: Dato og klokkeslett
 Definisjon: Dato som er påført selve dokumentet

--- a/metadata/M104.yaml
+++ b/metadata/M104.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres ved automatisk registrering, dato for mottak av
   fysiske dokumenter skal kunne endres inntil arkivering
 Datatype: Dato og klokkeslett

--- a/metadata/M105.yaml
+++ b/metadata/M105.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres ved automatisk registrering, dato for forsendelse
   av fysiske dokumenter skal kunne endres inntil arkivering
 Datatype: Dato og klokkeslett

--- a/metadata/M106.yaml
+++ b/metadata/M106.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe, journalpost
 Arv: Nei
-Avleveres:
 Betingelser: Utlån skal også kunne registreres etter at en saksmappe er avsluttet,
   eller etter at dokumentene i en journalpost ble arkivert.
 Datatype: Dato og klokkeslett

--- a/metadata/M107.yaml
+++ b/metadata/M107.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel
 Arv: Nei
-Avleveres: A
 Betingelser: Skal kunne endres manuelt
 Datatype: Dato og klokkeslett
 Definisjon: Dato for starten av en arkivperiode

--- a/metadata/M108.yaml
+++ b/metadata/M108.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel
 Arv: Nei
-Avleveres: A
 Betingelser: Skal kunne endres manuelt.
 Datatype: Dato og klokkeslett
 Definisjon: Dato for slutten av en arkivperiode

--- a/metadata/M109.yaml
+++ b/metadata/M109.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres:
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato som angir fristen for når et inngående dokument må være besvart

--- a/metadata/M110.yaml
+++ b/metadata/M110.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres:
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Datoen da offentlighetsvurdering ble foretatt

--- a/metadata/M111.yaml
+++ b/metadata/M111.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe eller journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Datoen på presedensen

--- a/metadata/M112.yaml
+++ b/metadata/M112.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: 'Egne filer med journalutskrift for løpende og offentlig journal: loependeJournal.xml
   og offentligJournal.xml.'
 Arv:
-Avleveres: A
 Betingelser: Startdato skal selekteres på *M101 journaldato*
 Datatype: Dato og klokkeslett
 Definisjon: Startdato for journalutskriftene som inngår i avleveringspakken.

--- a/metadata/M113.yaml
+++ b/metadata/M113.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: 'Egne filer med journalutskrift for løpende og offentlig journal: loependeJournal.xml
   og offentligJournal.xml.'
 Arv:
-Avleveres: A
 Betingelser: Sluttdato skal selekteres på *M101 journaldato*
 Datatype: Dato og klokkeslett
 Definisjon: Sluttdato for journalutskriftene som inngår i avleveringspakken.

--- a/metadata/M114.yaml
+++ b/metadata/M114.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Overordnet informasjon om innholdet i avleverinspakken.
 Arv: Nei
-Avleveres: A
 Betingelser: Startdatoen kan selekteres på M602 avsluttetDato for mappen. Andre seleksjonskriterier kan være aktuelle.
 Datatype: Dato
 Definisjon: Startdato avleveringspakken.

--- a/metadata/M115.yaml
+++ b/metadata/M115.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Overordnet informasjon om innholdet i avleverinspakken.
 Arv: Nei
-Avleveres: A
 Betingelser: Sluttdatoen kan selekteres på M602 avsluttetDato for mappen. Andre seleksjonskriterier kan være aktuelle.
 Datatype: Dato
 Definisjon: Sluttdato for avleveringspakken.

--- a/metadata/M200.yaml
+++ b/metadata/M200.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klasse, mappe, registrering
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres. 
 Datatype: systemID
 Definisjon: Referanse til den arkivenheten i hierarkiet som er direkte overordnet denne arkivenheten

--- a/metadata/M201.yaml
+++ b/metadata/M201.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klasse, mappe, registrering
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres.
 Datatype: systemID
 Definisjon: Referanse til den eller de arkivenhetene i hierarkiet som er direkte underordnet denne arkivenheten

--- a/metadata/M202.yaml
+++ b/metadata/M202.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til den arkivdelen som er forløper for denne arkivdelen, dvs.

--- a/metadata/M203.yaml
+++ b/metadata/M203.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til den arkivdelen som er arvtaker for denne arkivdelen, dvs.

--- a/metadata/M204.yaml
+++ b/metadata/M204.yaml
@@ -1,7 +1,6 @@
 
 Arkivenhet: arkivdel
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til det klassifikasjonssystemet som mappene i denne arkivdelen er klassifisert etter

--- a/metadata/M205.yaml
+++ b/metadata/M205.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til  mapper som tilhører en arkivdel

--- a/metadata/M206.yaml
+++ b/metadata/M206.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, dokumentbeskrivelse, dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til registreringer som er knyttet til denne enheten

--- a/metadata/M207.yaml
+++ b/metadata/M207.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: registrering, dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til dokumentbeskrivelser som tilknyttet denne arkivenheten

--- a/metadata/M208.yaml
+++ b/metadata/M208.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til arkivdelen som denne arkivenheten er tilknyttet

--- a/metadata/M209.yaml
+++ b/metadata/M209.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til sekundærklassifikasjon. Kan også referere til flere enn

--- a/metadata/M210.yaml
+++ b/metadata/M210.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse til en *mappe* fra en annen *mappe* eller *registrering*

--- a/metadata/M211.yaml
+++ b/metadata/M211.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse fra en mappe til en annen mappe eller registrering

--- a/metadata/M212.yaml
+++ b/metadata/M212.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse til en *registrering* fra en annen *registrering* eller

--- a/metadata/M213.yaml
+++ b/metadata/M213.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse fra en registrering til en annen registrering eller saksmappe

--- a/metadata/M214.yaml
+++ b/metadata/M214.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til en eller flere journalposter som blir avskrevet av denne journalposten

--- a/metadata/M215.yaml
+++ b/metadata/M215.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til en eller flere journalposter som avskriver denne journalposten

--- a/metadata/M216.yaml
+++ b/metadata/M216.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til dokumentobjektet

--- a/metadata/M217.yaml
+++ b/metadata/M217.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M218.yaml
+++ b/metadata/M218.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til filen som inneholder det elektroniske dokumentet som dokumentobjektet

--- a/metadata/M219.yaml
+++ b/metadata/M219.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: klasse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til en annen klasse

--- a/metadata/M220.yaml
+++ b/metadata/M220.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: klasse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Kryssreferanse fra en annen klasse

--- a/metadata/M221.yaml
+++ b/metadata/M221.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moetemappe
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til forrige utvalgsmøte

--- a/metadata/M222.yaml
+++ b/metadata/M222.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moetemappe
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til neste utvalgsmøte

--- a/metadata/M223.yaml
+++ b/metadata/M223.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moeteregistrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til en annen møteregistrering

--- a/metadata/M224.yaml
+++ b/metadata/M224.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moeteregistrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse fra en annen møteregistrering

--- a/metadata/M225.yaml
+++ b/metadata/M225.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse, dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Obligatorisk ved bruk av Noark 5 tjenestegrensesnitt
 Datatype: systemID
 Definisjon: Referanse til bruker som opprettet/registrerte arkivenheten

--- a/metadata/M226.yaml
+++ b/metadata/M226.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til bruker som oppdaterte arkivenheten

--- a/metadata/M227.yaml
+++ b/metadata/M227.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse og mappe
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivenheten er avsluttet. Obligatorisk ved bruk av Noark 5 tjenestegrensesnitt.
 Datatype: systemID
 Definisjon: Referanse til bruker som avsluttet/lukket arkivenheten

--- a/metadata/M228.yaml
+++ b/metadata/M228.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: registrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til bruker som arkiverte arkivenheten

--- a/metadata/M229.yaml
+++ b/metadata/M229.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: systemID
 Definisjon: Referanse til overordnet mappe

--- a/metadata/M230.yaml
+++ b/metadata/M230.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse samt filen endringslogg.xml
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: systemID
 Definisjon: Referanse til bruker som oppdaterte arkivenheten eller endret metadata

--- a/metadata/M300.yaml
+++ b/metadata/M300.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M301.yaml
+++ b/metadata/M301.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Stedet hvor de fysiske dokumentene oppbevares. Kan være angivelse av rom,

--- a/metadata/M302.yaml
+++ b/metadata/M302.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på virksomhet eller person som er part

--- a/metadata/M303.yaml
+++ b/metadata/M303.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Her er det mange tenkelige roller, f.eks.
 

--- a/metadata/M304.yaml
+++ b/metadata/M304.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall fysiske vedlegg til et fysisk hoveddokument

--- a/metadata/M305.yaml
+++ b/metadata/M305.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe, journalpost, moeteregistrering
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på avdeling, kontor eller annen administrativ enhet som har ansvaret

--- a/metadata/M306.yaml
+++ b/metadata/M306.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe
 Arv: Ja til journalpost, jf. *M307 saksbehandler*
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som er saksansvarlig

--- a/metadata/M307.yaml
+++ b/metadata/M307.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: journalpost, moeteregistrering
 Arv: Ja fra saksmappe til journalpost, jf. *M306* *saksansvarlig.* Saksansvarlig og
   saksbehandler vil i mange tilfeller være samme person.
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som er saksbehandler

--- a/metadata/M308.yaml
+++ b/metadata/M308.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe, journalpost
 Arv: Ja fra saksmappe til journalpost
-Avleveres: A
 Betingelser: Er ikke lenger obligatorisk i Noark 5. Journalenhet er helt uavhengig
   av administrativ enhet. Kan f.eks. brukes som seleksjonskriterium ved produksjon
   av rapporter. Det anbefales ikke å knytte tilgangsrettigheter til journalenhet.

--- a/metadata/M309.yaml
+++ b/metadata/M309.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe, journalpost
 Arv: Nei
-Avleveres:
 Betingelser: Utlån skal også kunne registreres etter at en saksmappe er avsluttet,
   eller at dokumentene i en journalpost ble arkivert
 Datatype: Tekststreng

--- a/metadata/M310.yaml
+++ b/metadata/M310.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering og dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Merknad fra saksbehandler, leder eller arkivpersonale.

--- a/metadata/M311.yaml
+++ b/metadata/M311.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe eller journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Lovparagrafen som saken eller journalposten danner presedens for

--- a/metadata/M312.yaml
+++ b/metadata/M312.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe eller journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: En argumentkilde som brukes til å løse rettslige problemer. En retts­anvender

--- a/metadata/M313.yaml
+++ b/metadata/M313.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: 'Egne filer med journalutskrift for løpende og offentlig journal: loependeJournal.xml
   og offentligJournal.xml'
 Arv:
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Beskrivelse av kriteriene som er brukt ved seleksjon av journalrapportenes

--- a/metadata/M370.yaml
+++ b/metadata/M370.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moetemappe
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på utvalget som avholdt møte

--- a/metadata/M371.yaml
+++ b/metadata/M371.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moetemappe
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Sted hvor møtet ble avholdt

--- a/metadata/M372.yaml
+++ b/metadata/M372.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moetemappe
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som var til stedet på møtet

--- a/metadata/M373.yaml
+++ b/metadata/M373.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: moetemappe
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Ingen obligatoriske typer. Aktuelle verdier kan f.eks. være:
 

--- a/metadata/M400.yaml
+++ b/metadata/M400.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: korrespondansepart
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person eller organisasjon som er avsender eller mottaker av dokumentet

--- a/metadata/M406.yaml
+++ b/metadata/M406.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: korrespondansepart, part
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Postadressen til en avsender /mottaker eller part

--- a/metadata/M407.yaml
+++ b/metadata/M407.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: korrespondansepart, part
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Postnummeret til en avsender /mottaker eller part

--- a/metadata/M408.yaml
+++ b/metadata/M408.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: korrespondansepart, part
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Poststedet til en avsender/mottaker eller part

--- a/metadata/M409.yaml
+++ b/metadata/M409.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: korrespondansepart, part
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Land dersom adressen er i utlandet

--- a/metadata/M410.yaml
+++ b/metadata/M410.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: korrespondansepart, part
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: E-postadressen til en avsender/mottaker eller part

--- a/metadata/M411.yaml
+++ b/metadata/M411.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: korrespondansepart, part
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Telefonnummeret til en avsender/mottaker eller part

--- a/metadata/M412.yaml
+++ b/metadata/M412.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: korrespondansepart, part
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Kontaktperson hos en organisasjon som er avsender eller mottaker, eller

--- a/metadata/M450.yaml
+++ b/metadata/M450.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, klasse, mappe, registrering, dokument­beskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M451.yaml
+++ b/metadata/M451.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, klasse, mappe, registrering, dokument­beskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall år dokumentene som tilhører denne arkivdelen skal bevares.

--- a/metadata/M452.yaml
+++ b/metadata/M452.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato for når dokumentene som tilhører denne arkivenheten skal kunne kasseres,

--- a/metadata/M453.yaml
+++ b/metadata/M453.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, klasse, mappe, registrering, dokumentbeskrivelse
 Arv:
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Angivelse av hjemmel for kassasjon

--- a/metadata/M500.yaml
+++ b/metadata/M500.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser: |-
   Obligatorisk verdi:
 

--- a/metadata/M501.yaml
+++ b/metadata/M501.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Henvisning til hjemmel (paragraf) i offentlighetsloven, sikkerhetsloven

--- a/metadata/M502.yaml
+++ b/metadata/M502.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M503.yaml
+++ b/metadata/M503.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M504.yaml
+++ b/metadata/M504.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser:
 Datatype: Heltall
 Definisjon: Antall år skjermingen skal opprettholdes.

--- a/metadata/M505.yaml
+++ b/metadata/M505.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Datoen skjermingen skal oppheves.

--- a/metadata/M506.yaml
+++ b/metadata/M506.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M507.yaml
+++ b/metadata/M507.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, dokumentbeskrivelse, dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Aktuelle verdier:
 

--- a/metadata/M508.yaml
+++ b/metadata/M508.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, dokumentbeskrivelse, dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M580.yaml
+++ b/metadata/M580.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Brukeradministrasjon inngår ikke i arkivstrukturen
 Arv: Nei
-Avleveres:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på bruker av en Noark 5-løsning

--- a/metadata/M581.yaml
+++ b/metadata/M581.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Brukeradministrasjon inngår ikke i arkivstrukturen
 Arv: Nei
-Avleveres:
 Betingelser: |-
   Ingen obligatoriske verdier. Aktuelle verdier kan være:
 

--- a/metadata/M582.yaml
+++ b/metadata/M582.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Brukeradministrasjon inngår ikke i arkivstrukturen
 Arv: Nei
-Avleveres:
 Betingelser: |-
   Ingen obligatoriske verdier. Aktuelle verdier kan være:
 

--- a/metadata/M583.yaml
+++ b/metadata/M583.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Administrasjonsstrukturen inngår ikke i arkivstrukturen
 Arv: Nei
-Avleveres:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på administrativ enhet

--- a/metadata/M584.yaml
+++ b/metadata/M584.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Administrasjonsstrukturen inngår ikke i arkivstrukturen
 Arv: Nei
-Avleveres:
 Betingelser: |-
   Ingen obligatoriske verdier. Aktuelle verdier kan være:
 

--- a/metadata/M585.yaml
+++ b/metadata/M585.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Administrasjonsstrukturen inngår ikke i arkivstrukturen
 Arv: Nei
-Avleveres:
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til enhet som er direkte overordnet denne enheten

--- a/metadata/M600.yaml
+++ b/metadata/M600.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse,
   dokumentobjekt, også presedens
 Arv: Nei
-Avleveres:
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten ble opprettet/registrert

--- a/metadata/M601.yaml
+++ b/metadata/M601.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse,
   dokumentobjekt
 Arv: Nei
-Avleveres:
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Navn på person som opprettet/registrerte arkivenheten

--- a/metadata/M602.yaml
+++ b/metadata/M602.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse og mappe
 Arv: Nei
-Avleveres:
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivdelen er avsluttet.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten ble avsluttet/lukket

--- a/metadata/M603.yaml
+++ b/metadata/M603.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse og mappe
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivenheten er avsluttet.
 Datatype: Tekststreng
 Definisjon: Navn på person som avsluttet/lukket arkivenheten

--- a/metadata/M604.yaml
+++ b/metadata/M604.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: registrering
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når alle dokumentene som er tilknyttet registreringen

--- a/metadata/M605.yaml
+++ b/metadata/M605.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: registrering
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som arkiverte dokumentet og frøs det for all videre redigering

--- a/metadata/M606.yaml
+++ b/metadata/M606.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Egen fil
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har foretatt (eller er ansvarlig for) eksport av metadata og dokumenter

--- a/metadata/M607.yaml
+++ b/metadata/M607.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Egen fil
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når eksporten skjedde

--- a/metadata/M608.yaml
+++ b/metadata/M608.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Egen fil
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Antall mapper som inngikk i eksporten

--- a/metadata/M609.yaml
+++ b/metadata/M609.yaml
@@ -1,7 +1,6 @@
 Arkivenhet: 'Egne filer med journalutskrift for løpende og offentlig journal: loependeJournal.xml
   og offentligJournal.xml.'
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Heltall
 Definisjon: Antall journalposter i rapporten

--- a/metadata/M610.yaml
+++ b/metadata/M610.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Egen fil
 Arv: Nei
-Avleveres: A
 Betingelser: Obligatorisk ved avlevering dersom eksporten omfatter elektroniske dokumenter. Kan ikke endres
 Datatype: Heltall
 Definisjon: Antall elektroniske dokumenter (dokumentfiler) som inngikk i eksporten

--- a/metadata/M611.yaml
+++ b/metadata/M611.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering og dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når merknaden ble registrert

--- a/metadata/M612.yaml
+++ b/metadata/M612.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering og dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har registrert merknaden

--- a/metadata/M613.yaml
+++ b/metadata/M613.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble slettet

--- a/metadata/M614.yaml
+++ b/metadata/M614.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkivdel, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har utført en kontrollert kassasjon av dokumenter,

--- a/metadata/M615.yaml
+++ b/metadata/M615.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett for når et dokument ble konvertert fra et format til

--- a/metadata/M616.yaml
+++ b/metadata/M616.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Person eller system som har foretatt konverteringen

--- a/metadata/M617.yaml
+++ b/metadata/M617.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato et dokument ble avskrevet

--- a/metadata/M618.yaml
+++ b/metadata/M618.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har foretatt avskrivning

--- a/metadata/M619.yaml
+++ b/metadata/M619.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M620.yaml
+++ b/metadata/M620.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Datoen et dokument ble knyttet til en registrering

--- a/metadata/M621.yaml
+++ b/metadata/M621.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som knyttet et dokument til en registrering

--- a/metadata/M622.yaml
+++ b/metadata/M622.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, dokumentbeskrivelse, dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato en elektronisk signatur ble verifisert

--- a/metadata/M623.yaml
+++ b/metadata/M623.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, dokumentbeskrivelse, dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har verifisert en elektronisk signatur

--- a/metadata/M624.yaml
+++ b/metadata/M624.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble gradert

--- a/metadata/M625.yaml
+++ b/metadata/M625.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Ja
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som foretok graderingen

--- a/metadata/M626.yaml
+++ b/metadata/M626.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når et dokument ble nedgradert

--- a/metadata/M627.yaml
+++ b/metadata/M627.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som foretok nedgraderingen

--- a/metadata/M628.yaml
+++ b/metadata/M628.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe eller journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett for når presedensen er godkjent

--- a/metadata/M629.yaml
+++ b/metadata/M629.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe eller journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på person som har godkjent presedensen

--- a/metadata/M630.yaml
+++ b/metadata/M630.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når kassasjonen ble utført

--- a/metadata/M631.yaml
+++ b/metadata/M631.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Navn på person som har utført kassasjonen

--- a/metadata/M632.yaml
+++ b/metadata/M632.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres.
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten sist ble oppdatert

--- a/metadata/M633.yaml
+++ b/metadata/M633.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres.
 Datatype: Tekststreng
 Definisjon: Dato og klokkeslett når arkivenheten sist ble oppdatert

--- a/metadata/M660.yaml
+++ b/metadata/M660.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, arkivnotat
 Arv: Nei
-Avleveres: A
 Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke kunne
   endres
 Datatype: Tekststreng

--- a/metadata/M661.yaml
+++ b/metadata/M661.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, arkivnotat
 Arv: Nei
-Avleveres: A
 Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke kunne
   endres.
 Datatype: Dato og klokkeslett

--- a/metadata/M662.yaml
+++ b/metadata/M662.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, arkivnotat
 Arv: Nei
-Avleveres: A
 Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke kunne
   endres.
 Datatype: Dato og klokkeslett

--- a/metadata/M663.yaml
+++ b/metadata/M663.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, arkivnotat
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Anbefalte verdier:
 

--- a/metadata/M664.yaml
+++ b/metadata/M664.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, arkivnotat
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Merknad eller kommentar til et dokument som er sendt på flyt

--- a/metadata/M665.yaml
+++ b/metadata/M665.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: journalpost, arkivnotat
 Arv: Nei
-Avleveres: A
 Betingelser: Obligatorisk dersom dokumentet har blitt sendt på flyt. Skal ikke kunne
   endres.
 Datatype: Tekststreng

--- a/metadata/M666.yaml
+++ b/metadata/M666.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe, journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Person som har fått fordelt en saksmappe eller journalpost til saksbehandling

--- a/metadata/M667.yaml
+++ b/metadata/M667.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe, journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Person som har fordelt en saksmappe eller journalpost til saksbehandling

--- a/metadata/M668.yaml
+++ b/metadata/M668.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: saksmappe, journalpost
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Dato da en saksmappe eller journalpost ble fordelt til saksbehandling

--- a/metadata/M680.yaml
+++ b/metadata/M680.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Filen endringslogg.xml
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Referanse til arkivenheten (systemID) som inneholder metadata­elementet

--- a/metadata/M681.yaml
+++ b/metadata/M681.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Filen endringslogg.xml
 Arv:
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navnet på metadataelementet som ble endret

--- a/metadata/M682.yaml
+++ b/metadata/M682.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse samt filen endringslogg.xml
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett
 Definisjon: Dato og klokkeslett når arkivenheten ble oppdatert eller et metadataelement sist ble endret

--- a/metadata/M683.yaml
+++ b/metadata/M683.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse samt filen endringslogg.xml
 Arv: Nei
-Avleveres: A
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng
 Definisjon: Navn på person som oppdaterte en arkivenhet eller endret metadata

--- a/metadata/M684.yaml
+++ b/metadata/M684.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Filen endringslogg.xml
 Arv:
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Innholdet i metadataelementet før det ble endret

--- a/metadata/M685.yaml
+++ b/metadata/M685.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Filen endringslogg.xml
 Arv:
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Det nye innholdet i metadataelementet

--- a/metadata/M700.yaml
+++ b/metadata/M700.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: |-
   Obligatoriske verdier:
 

--- a/metadata/M701.yaml
+++ b/metadata/M701.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Dokumentets format

--- a/metadata/M702.yaml
+++ b/metadata/M702.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Nærmere spesifikasjon av dokuments format, f.eks. informasjon om komprimering

--- a/metadata/M703.yaml
+++ b/metadata/M703.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Dokumentets format før det ble konvertert

--- a/metadata/M704.yaml
+++ b/metadata/M704.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Nærmere spesifikasjon av dokuments format før det ble konvertert, f.eks. informasjon om komprimering

--- a/metadata/M705.yaml
+++ b/metadata/M705.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres. Sjekksummen skal være heksadesimal uten noen formatteringstegn.
 Datatype: Tekststreng
 Definisjon: En verdi som beregnes ut fra innholdet i dokumentet, og som dermed gir

--- a/metadata/M706.yaml
+++ b/metadata/M706.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres. Algoritmen som skal brukes inntil videre er SHA256.
 Datatype: Tekststreng
 Definisjon: Algoritmen som er brukt for å beregne sjekksummen

--- a/metadata/M707.yaml
+++ b/metadata/M707.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Størrelsen på fila i antall bytes oppgitt med desimaltall

--- a/metadata/M708.yaml
+++ b/metadata/M708.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Egen fil
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: En verdi som beregnes ut fra innholdet i metadataobjektene i avleveringspakken, og som dermed gir integritessikring til metadataenes innhold

--- a/metadata/M709.yaml
+++ b/metadata/M709.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: Egen fil
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: En verdi som beregnes ut fra innholdet i hele avleveringspakken (både metadata- og dokumentobjekter), og som dermed gir integritetssikring til hele  avleveringspakken

--- a/metadata/M711.yaml
+++ b/metadata/M711.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: mappe, registrering, dokumentbeskrivelse, part
 Arv:
-Avleveres: A
 Betingelser:
 Datatype: Vilkårlig struktur
 Definisjon: Et overordnet metadataelement som kan inneholde egendefinerte metadata.

--- a/metadata/M712.yaml
+++ b/metadata/M712.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Formatet dokumentet hadde før det ble konvertert

--- a/metadata/M713.yaml
+++ b/metadata/M713.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Formatet dokumentet fikk etter konvertering

--- a/metadata/M714.yaml
+++ b/metadata/M714.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Navn på det IT-verktøyet som ble brukt til å foreta konverteringen

--- a/metadata/M715.yaml
+++ b/metadata/M715.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser:
 Datatype: Tekststreng
 Definisjon: Kommentarer til konverteringen

--- a/metadata/M716.yaml
+++ b/metadata/M716.yaml
@@ -1,6 +1,5 @@
 Arkivenhet: dokumentobjekt
 Arv: Nei
-Avleveres: A
 Betingelser: Kan ikke endres
 Datatype: Tekststreng
 Definisjon: Dokumentets MIME-type

--- a/scripts/metadata-xml2yaml
+++ b/scripts/metadata-xml2yaml
@@ -27,7 +27,6 @@ class Converter(object):
         for sub in element.iterchildren():
             entry = {
                 'Datatype': '?',
-                'Avleveres': '?',
             }
             for line in sub.iterchildren():
                 field = line.tag

--- a/scripts/metadata2rst
+++ b/scripts/metadata2rst
@@ -8,7 +8,7 @@ import yaml
 
 def main():
     retval = 0
-    required = ('Nr', 'Navn', 'Datatype', 'Avleveres',
+    required = ('Nr', 'Navn', 'Datatype',
                 'Definisjon', 'Arkivenhet', 'Kilde')
     optional = ('Noark 4', 'Arv', 'Betingelser', 'Kommentarer',)
     parser = argparse.ArgumentParser()
@@ -60,7 +60,7 @@ def main():
             print("By %s" % unit)
             for number in byunit[unit]:
                 line = []
-                for f in ('Nr', 'Navn', 'Avleveres', 'Datatype'):
+                for f in ('Nr', 'Navn', 'Datatype'):
                     line.append(byunit[unit][number][f])
                 print(line)
             print()

--- a/scripts/metadata2xsd
+++ b/scripts/metadata2xsd
@@ -55,7 +55,7 @@ class XMLFile(object):
 
 def main():
     retval = 0
-    required = ('Nr', 'Navn', 'Datatype', 'Avleveres',
+    required = ('Nr', 'Navn', 'Datatype',
                 'Definisjon', 'Arkivenhet', 'Kilde')
     optional = ('Noark 4', 'Arv', 'Betingelser', 'Kommentarer',)
     parser = argparse.ArgumentParser()

--- a/scripts/metadatarst2yaml
+++ b/scripts/metadatarst2yaml
@@ -69,10 +69,10 @@ class MetadataRstVisitor(docutils.nodes.NodeVisitor):
         self.entry['Gjeldende'] = True
 
         if self.entry['Nr'] in self.metadata:
-            for field in ('Avleveres', 'Datatype'):
+            for field in ('Datatype'):
                 self.entry[field] = self.metadata[self.entry['Nr']][field]
         else:
-            for field in ('Avleveres', 'Datatype'):
+            for field in ('Datatype'):
                 self.entry[field] = '?'
         filepath = 'metadata/%s.yaml' % self.entry['Nr']
         import sys


### PR DESCRIPTION
Avleveringsstatus varierer etter hvor metadataoppføringen blir brukt,
så det gir ikke mening å ha denne informasjon per M-kode.

Relatert til #24.