### PR TITLE
Samkjør avskrivning med Noark 5 Tjenstegrensesnitt og rydd i beskrivelser

### DIFF
--- a/kapitler/060-gjenfinning_innsyn_rapportering.rst
+++ b/kapitler/060-gjenfinning_innsyn_rapportering.rst
@@ -285,7 +285,7 @@ Kravene under er obligatoriske for sakarkivløsninger eller andre løsninger und
      
      *referanseAvskrivesAvJournalpost*
      
-     *referanseAvskriverJournalpost*
+     *referanseAvskrivesAvKorrespondansepart*
    - B
    - Obligatorisk for arkiv underlagt Offentleglova.
  * - 5.2.10

--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -859,6 +859,12 @@ Merk: Kun ett av feltene personID og organisasjonsID kan ha verdi.
    - **Forek.**
    - **Avl.**
    - **Datatype**
+ * - M001
+   - systemID
+   -
+   - 1
+   - A
+   - Tekststreng
  * - M087
    - korrespondanseparttype
    - (AM.IHTYPE, AM.KOPIMOT, AM.GRUPPE MOT)
@@ -1091,6 +1097,12 @@ Merk: Grupperes inn i den journalposten som avskrives.
    - 0-1
    - A
    - registrering.systemID
+ * - M231
+   - referanseAvskrivesAvKorrespondansepart
+   -
+   - 0-1
+   - A
+   - korrespondansepart.systemID
 
 Metadata for *arkivnotat*
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1698,6 +1710,12 @@ Merk: Kun ett av feltene personID og organisasjonsID kan ha verdi.
    - **Forek.**
    - **Avl.**
    - **Datatype**
+ * - M001
+   - systemID
+   -
+   - 1
+   - A
+   - Tekststreng
  * - M010
    - partID
    - 

--- a/kapitler/130-vedlegg_3_logg_over_endringer.rst
+++ b/kapitler/130-vedlegg_3_logg_over_endringer.rst
@@ -152,10 +152,6 @@ Når verdiene for noen sentrale metadataelementer blir endret, skal dette logges
    - journalenhet
    - Ved endring
  * - avskrivning
-   - M214
-   - referanseAvskriverJournalpost
-   - Ved endring
- * - avskrivning
    - M215
    - referanseAvskrivesAvJournalpost
    - Ved endring

--- a/metadata/M215.yaml
+++ b/metadata/M215.yaml
@@ -2,7 +2,7 @@ Arkivenhet: journalpost
 Arv: Nei
 Betingelser: Må inneholde gyldig systemID for registrering
 Datatype: systemID
-Definisjon: Referanse til en eller flere journalposter som avskriver denne journalposten
+Definisjon: Referanse til en journalpost som avskriver denne journalposten
 Gruppe: Referanser
 Kilde: Registreres manuelt eller automatisk ved avskrivning
 Kommentarer:

--- a/metadata/M231.yaml
+++ b/metadata/M231.yaml
@@ -1,0 +1,12 @@
+Arkivenhet: journalpost
+Arv: Nei
+Avleveres: A
+Betingelser:
+Datatype: systemID
+Definisjon: Referanse til korrespondansepart i journalpost som avskriver denne journalposten.
+Gruppe: Referanser
+Kilde: Registreres manuelt eller automatisk ved avskrivning
+Kommentarer:
+Navn: referanseAvskrivesAvKorrespondansepart
+Nr: M231
+Utdatert: nei


### PR DESCRIPTION
Beskrivelsen av M215 (og M214) sier det skal være mulig å koble til en eller
flere journalposter, mens objektbeskrivelsen av avskrivning sier 0-1, dvs
maksimum 1.  Antar metadatabeskrivelsen er feil og endrer denne til å si
'referanse til journalpost' i stedet.

I Noark 5 Tjenestegrensesnitt er det lagt til en ny attributt til avskrivning,
referanseAvskrivesAvKorrespondansepart.  For at denne skal ha noe å referer
til, så må korrespondansepart ha en unik ID.  I Noark 5 Tjenstegrensesnitt
er dette en systemID, og for å kunne avlevere disse verdiene med Noark 5 bør
også Noark 5 ha systemID koblet til korrespondansepart.  For konsistens
legger jeg også på en systemID på part, som strukturelt er identisk med
korrespondansepart.

Fjernet samtidig alle referanser til ubrukt M214 referanseAvskriverJournalpost,
som ikke har kobling til noen objekter og kun er omtalt som ønsket logget
og rapportert, samt markerer den som ikke lenger gjeldende slik at den
tas ut av spesifikasjonsteksten.

Denne endringen erstatter endringsforslag #66.

Fixes #65