### PR TITLE
Flytt virksomhetsspesifikkeMetadata til korrekt korrespondansepart

### DIFF
--- a/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
+++ b/kapitler/120-vedlegg_2_metadatakatalog_objektsortert.rst
@@ -937,6 +937,12 @@ Merk: Kun ett av feltene personID og organisasjonsID kan ha verdi.
    - 0-1
    - A
    - Tekststreng
+ * - M711
+   - virksomhetsspesifikkeMetadata
+   -
+   - 0-1
+   - A
+   - Vilkårlig struktur
 
 Metadata for *journalpost*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2694,12 +2700,6 @@ Metadata for *korrespondansepart*
    - 0-1
    - A
    - Tekststreng
- * - M711
-   - virksomhetsspesifikkeMetadata
-   -
-   - 0-1
-   - A
-   - Vilkårlig struktur
 
 Metadata for offentligJournal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Ved generering av XSD fra RST-filene oppdaget jeg at
virksomhetsspesifikkeMetadata for korrespondansepart var koblet til
feil korrespondansepart.  Skulle vært i arkivstruktur.xsd, ikke
loependeJournal.xsd.  Endringen flytter attributten til riktig sted.

Korrigerer feil introdusert i a45425b1a8ac567a20c2e8ae01806d5249fae93a .