### PR TITLE
Correct "ISO 14571" to "ISO 14721" in requirement 6.4.1

### DIFF
--- a/kapitler/070-funksjoner_for_periodiske_oppgaver.rst
+++ b/kapitler/070-funksjoner_for_periodiske_oppgaver.rst
@@ -545,7 +545,7 @@ OAIS grupperer den bevaringsbeskrivende informasjonen - dvs. metadataene - i fem
    - Obligatorisk ved avlevering til arkivdepot.
  * - 6.4.2
    - Arkivuttrekket skal utgjøre en avleveringspakke (Submission
-     Information Packages), slik dette er definert i ISO 14571 OAIS.
+     Information Packages), slik dette er definert i ISO 14721 OAIS.
    - B
    - Obligatorisk ved avlevering til arkivdepot.
  * - 6.4.3


### PR DESCRIPTION
This is about information transfer, not material measurement.

Thanks to Jørgen for reporting the issue

Fixes #140.