### PR TITLE
Associate arkivskaperID with arkivskaper object

### DIFF
--- a/metadata/M006.yaml
+++ b/metadata/M006.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkiv
+Arkivenhet: arkivskaper
 Arv: Nei
 Betingelser:
 Datatype: Tekststreng


### PR DESCRIPTION

Er ikke en arkivskaperID attributt assosiert med en arkivskaper arkivenhet, ikke en arkiv arkivenhet

Se feks https://github.com/arkivverket/schemas/blob/master/N5/v5.0/arkivstruktur.xsd#L95