### PR TITLE
Vis åndsverksvernestatus i README-filen på toppnivå

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,3 +22,13 @@ Oversettelser
 
 Teksten oversettes ved hjelp av
 https://hosted.weblate.org/projects/noark/noark5/
+
+Opphavsrettslig vern
+--------------------
+
+Denne spesifikasjonen faller inn under unntakene i åndsverkslovens §
+9, og er ikke opphavsrettslig vernet.
+
+Videredistribusjon og bruk i kildeformat (RST) og kompilert form (XML,
+HTML, PDF, PostScript, RTF og så videre) er tillatt både med og uten
+endringer.


### PR DESCRIPTION
Kopierte informasjon om åndsverksvernestatus fra docbook/spesifikasjon.xml til README.rst for å gjøre den enklere å finne også for de som ikke leser PDF-utgaven.