### PR TITLE
Dokumenter at listen over loggmeldinger skal tolkes som en minimumsliste.

### DIFF
--- a/kapitler/130-vedlegg_3_logg_over_endringer.rst
+++ b/kapitler/130-vedlegg_3_logg_over_endringer.rst
@@ -1,7 +1,7 @@
 Oversikt over metadata hvor det skal logges at det gjøres endringer i innholdet
 ===============================================================================
 
-Når verdiene for noen sentrale metadataelementer blir endret, skal dette logges. Nedenfor følger en oversikt over hvilke metadata det skal logges endringer for.
+Når verdiene for noen sentrale metadataelementer blir endret, skal dette logges. Nedenfor følger en oversikt over hvilke metadata det som minimum skal avleveres logg over endringer for.
 
 .. list-table::
    :widths: 3 1 5 3


### PR DESCRIPTION
Intensjonen er at listen beskriver minstekravet for logging, ikke et forbud mot å logge mer, og at dette gjelder hva som som minimum skal trekkes ut/avleveres fra et Noark 5-system.