### PR TITLE
Korriger og juster innhold og formattering av Arkivenhet-feltet i metadatakatalogen.

### DIFF
--- a/metadata/M056.yaml
+++ b/metadata/M056.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: saksmappe eller journalpost
+Arkivenhet: saksmappe, journalpost
 Arv: Nei
 Betingelser: |-
   Obligatoriske verdier:

--- a/metadata/M084.yaml
+++ b/metadata/M084.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: mappe, registrering og dokumentbeskrivelse
+Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
 Betingelser: |-
   Ingen obligatoriske typer. Aktuelle verdier kan f.eks. være:

--- a/metadata/M101.yaml
+++ b/metadata/M101.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: Journalpost
+Arkivenhet: journalpost
 Arv: Nei
 Betingelser: Skal kunne endres manuelt inntil arkivering
 Datatype: Dato og klokkeslett

--- a/metadata/M111.yaml
+++ b/metadata/M111.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: saksmappe eller journalpost
+Arkivenhet: saksmappe, journalpost
 Arv: Nei
 Betingelser:
 Datatype: Dato og klokkeslett

--- a/metadata/M227.yaml
+++ b/metadata/M227.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse og mappe
+Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe
 Arv: Nei
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivenheten er avsluttet. Obligatorisk ved bruk av Noark 5 tjenestegrensesnitt.
 Datatype: systemID

--- a/metadata/M230.yaml
+++ b/metadata/M230.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse samt filen endringslogg.xml
+Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse, filen endringslogg.xml
 Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: systemID

--- a/metadata/M310.yaml
+++ b/metadata/M310.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: mappe, registrering og dokumentbeskrivelse
+Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
 Betingelser:
 Datatype: Tekststreng

--- a/metadata/M311.yaml
+++ b/metadata/M311.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: saksmappe eller journalpost
+Arkivenhet: saksmappe, journalpost
 Arv: Nei
 Betingelser:
 Datatype: Tekststreng

--- a/metadata/M312.yaml
+++ b/metadata/M312.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: saksmappe eller journalpost
+Arkivenhet: saksmappe, journalpost
 Arv: Nei
 Betingelser:
 Datatype: Tekststreng

--- a/metadata/M450.yaml
+++ b/metadata/M450.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkivdel, klasse, mappe, registrering, dokument­beskrivelse
+Arkivenhet: arkivdel, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
 Betingelser: |-
   Obligatoriske verdier:

--- a/metadata/M451.yaml
+++ b/metadata/M451.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkivdel, klasse, mappe, registrering, dokument­beskrivelse
+Arkivenhet: arkivdel, klasse, mappe, registrering, dokumentbeskrivelse
 Arv: Ja
 Betingelser:
 Datatype: Heltall

--- a/metadata/M602.yaml
+++ b/metadata/M602.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse og mappe
+Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe
 Arv: Nei
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivdelen er avsluttet.
 Datatype: Dato og klokkeslett

--- a/metadata/M603.yaml
+++ b/metadata/M603.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse og mappe
+Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe
 Arv: Nei
 Betingelser: Skal ikke kunne endres. Obligatorisk dersom arkivenheten er avsluttet.
 Datatype: Tekststreng

--- a/metadata/M611.yaml
+++ b/metadata/M611.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: mappe, registrering og dokumentbeskrivelse
+Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Dato og klokkeslett

--- a/metadata/M612.yaml
+++ b/metadata/M612.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: mappe, registrering og dokumentbeskrivelse
+Arkivenhet: mappe, registrering, dokumentbeskrivelse
 Arv: Nei
 Betingelser: Kan ikke endres
 Datatype: Tekststreng

--- a/metadata/M628.yaml
+++ b/metadata/M628.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: saksmappe eller journalpost
+Arkivenhet: saksmappe, journalpost
 Arv: Nei
 Betingelser:
 Datatype: Dato og klokkeslett

--- a/metadata/M629.yaml
+++ b/metadata/M629.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: saksmappe eller journalpost
+Arkivenhet: saksmappe, journalpost
 Arv: Nei
 Betingelser:
 Datatype: Tekststreng

--- a/metadata/M680.yaml
+++ b/metadata/M680.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: Filen endringslogg.xml
+Arkivenhet: filen endringslogg.xml
 Arv: Nei
 Betingelser: Må inneholde gyldig systemID for aktuell arkivenhet
 Datatype: Tekststreng

--- a/metadata/M681.yaml
+++ b/metadata/M681.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: Filen endringslogg.xml
+Arkivenhet: filen endringslogg.xml
 Arv:
 Betingelser:
 Datatype: Tekststreng

--- a/metadata/M682.yaml
+++ b/metadata/M682.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse samt filen endringslogg.xml
+Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse, filen endringslogg.xml
 Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Dato og klokkeslett

--- a/metadata/M683.yaml
+++ b/metadata/M683.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse samt filen endringslogg.xml
+Arkivenhet: arkiv, arkivdel, klassifikasjonssystem, klasse, mappe, registrering, dokumentbeskrivelse, filen endringslogg.xml
 Arv: Nei
 Betingelser: Skal ikke kunne endres
 Datatype: Tekststreng

--- a/metadata/M684.yaml
+++ b/metadata/M684.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: Filen endringslogg.xml
+Arkivenhet: filen endringslogg.xml
 Arv:
 Betingelser:
 Datatype: Tekststreng

--- a/metadata/M685.yaml
+++ b/metadata/M685.yaml
@@ -1,4 +1,4 @@
-Arkivenhet: Filen endringslogg.xml
+Arkivenhet: filen endringslogg.xml
 Arv:
 Betingelser:
 Datatype: Tekststreng


### PR DESCRIPTION
Dette gjør feltet enklere å behandle maskinelt, og sikrer konsistent navngiving ute store bokstaver og navngiving identisk med XML-skjema.

Korrigerer feilaktige ordelinger, bytter ut 'og' og 'eller' med komma, samt sikrer at hver entitet har konsistent bokstavering.

Status før endringen:

% grep ^Arkivenhet metadata/*|sort -u|cut -d: -f3-|tr , "\n"|sort|uniq -c|sort -nr
     51  registrering
     49  mappe
     47  dokumentbeskrivelse
     37  journalpost
     37  arkivdel
     25  klasse
     24  dokumentobjekt
     22  arkiv
     16  klassifikasjonssystem
     12  saksmappe
     12  part
     11  korrespondansepart
      8  moetemappe
      7  moeteregistrering
      6  saksmappe eller journalpost
      6  Egen fil
      6  arkivnotat
      5  matrikkelnummer
      4  registrering og dokumentbeskrivelse
      4  posisjon
      4  planident
      4  konvertering
      4  Filen endringslogg.xml
      4  'Egne filer med journalutskrift for løpende og offentlig journal: loependeJournal.xml
      3  klasse og mappe
      3  dokumentbeskrivelse samt filen endringslogg.xml
      3  Brukeradministrasjon inngår ikke i arkivstrukturen
      3  Administrasjonsstrukturen inngår ikke i arkivstrukturen
      3
      2  Overordnet informasjon om innholdet i avleverinspakken.
      2  dokument­beskrivelse
      2  byggident
      1  Journalpost
%

Status etter endringen:

% grep ^Arkivenhet metadata/*|sort -u|cut -d: -f3-|tr , "\n"|sort|uniq -c|sort -nr
     56  dokumentbeskrivelse
     55  registrering
     52  mappe
     44  journalpost
     37  arkivdel
     28  klasse
     24  dokumentobjekt
     22  arkiv
     18  saksmappe
     16  klassifikasjonssystem
     12  part
     11  korrespondansepart
      8  moetemappe
      7  moeteregistrering
      7  filen endringslogg.xml
      6  Egen fil
      6  arkivnotat
      5  matrikkelnummer
      4  posisjon
      4  planident
      4  konvertering
      4  'Egne filer med journalutskrift for løpende og offentlig journal: loependeJournal.xml
      3  Brukeradministrasjon inngår ikke i arkivstrukturen
      3  Administrasjonsstrukturen inngår ikke i arkivstrukturen
      3
      2  Overordnet informasjon om innholdet i avleverinspakken.
      2  byggident
%