### PR TITLE
Korrigerte skrivefeil i beskrivelse av M025 (M504 -> M502).

### DIFF
--- a/kapitler/110-vedlegg_1_metadatakatalog-auto.rst
+++ b/kapitler/110-vedlegg_1_metadatakatalog-auto.rst
@@ -473,7 +473,7 @@ Kjernemetadata (jf. Dublin Core)
    * - **Arv**
      - 
    * - **Betingelser**
-     - Obligatorisk i arkivuttrekk dersom tittelen inneholder ord som skal skjermes, jf. *M504 skjermingMetadata.*
+     - Obligatorisk i arkivuttrekk dersom tittelen inneholder ord som skal skjermes, jf. *M502 skjermingMetadata.*
    * - **Kommentarer**
      - I løpende og offentlig journaler skal også offentligTittel være med dersom ord i tittelfeltet skal skjermes.
 

--- a/metadata/M025.yaml
+++ b/metadata/M025.yaml
@@ -1,7 +1,7 @@
 Arkivenhet: mappe, registrering
 Arv:
 Betingelser: Obligatorisk i arkivuttrekk dersom tittelen inneholder ord som skal skjermes,
-  jf. *M504 skjermingMetadata.*
+  jf. *M502 skjermingMetadata.*
 Datatype: Tekststreng
 Definisjon: Offentlig tittel på arkivenheten, ord som skal skjermes er fjernet fra
   innholdet i tittelen (erstattet med ******)


### PR DESCRIPTION
Omtalt feltnavn var for M502, ikke M504.

Takk til Jørgen for å ha oppdaget feilen.

Fixes #157.